### PR TITLE
Feature/mz 159 Textfield Component

### DIFF
--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/PriceVisualTransformation.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/PriceVisualTransformation.kt
@@ -9,7 +9,12 @@ import java.text.DecimalFormat
 class PriceVisualTransformation : VisualTransformation {
     override fun filter(text: AnnotatedString): TransformedText {
         val amount = text.text
-        val formatAmount = if (amount.isEmpty()) "" else DecimalFormat("#,###").format(amount.toBigDecimal())
+
+        if (amount.isEmpty()) {
+            return TransformedText(AnnotatedString(""), OffsetMapping.Identity)
+        }
+
+        val formatAmount = DecimalFormat("#,###").format(amount.toBigDecimal())
 
         return TransformedText(
             text = AnnotatedString("${formatAmount}원"),

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/PriceVisualTransformation.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/PriceVisualTransformation.kt
@@ -18,18 +18,24 @@ class PriceVisualTransformation : VisualTransformation {
                     if (offset <= 1) return offset
 
                     val entireCommaCount = if (amount.length % 3 == 0) amount.length / 3 - 1 else amount.length / 3
-                    val commaBeforeOffsetCount = formatAmount.substring(0 until offset + entireCommaCount).count { it == ',' }
+                    val sliceUntil = if (offset + entireCommaCount <= formatAmount.length) offset + entireCommaCount else formatAmount.length
+                    val commaBeforeOffsetCount = formatAmount.substring(0 until sliceUntil).count { it == ',' }
 
                     return offset + commaBeforeOffsetCount
                 }
 
                 override fun transformedToOriginal(offset: Int): Int {
-                    if (offset <= 1) return offset
+                    return when (offset) {
+                        in 0..1 -> offset
+                        in 2 until formatAmount.length -> {
+                            val entireCommaCount = if (amount.length % 3 == 0) amount.length / 3 - 1 else amount.length / 3
+                            val sliceUntil = if (offset + entireCommaCount <= formatAmount.length) offset + entireCommaCount else formatAmount.length
+                            val commaBeforeOffsetCount = formatAmount.substring(0 until sliceUntil).count { it == ',' }
+                            offset - commaBeforeOffsetCount
+                        }
 
-                    val entireCommaCount = if (amount.length % 3 == 0) amount.length / 3 - 1 else amount.length / 3
-                    val commaBeforeOffsetCount = formatAmount.substring(0 until offset + entireCommaCount).count { it == ',' }
-
-                    return offset - commaBeforeOffsetCount
+                        else -> amount.length
+                    }
                 }
             },
         )

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/PriceVisualTransformation.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/PriceVisualTransformation.kt
@@ -6,7 +6,9 @@ import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 import java.text.DecimalFormat
 
-class PriceVisualTransformation : VisualTransformation {
+class PriceVisualTransformation(
+    private val postfix: String,
+) : VisualTransformation {
     override fun filter(text: AnnotatedString): TransformedText {
         val amount = text.text
 
@@ -17,7 +19,7 @@ class PriceVisualTransformation : VisualTransformation {
         val formatAmount = DecimalFormat("#,###").format(amount.toBigDecimal())
 
         return TransformedText(
-            text = AnnotatedString("${formatAmount}원"),
+            text = AnnotatedString(formatAmount + postfix),
             offsetMapping = object : OffsetMapping {
                 override fun originalToTransformed(offset: Int): Int {
                     if (offset <= 1) return offset

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/PriceVisualTransformation.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/PriceVisualTransformation.kt
@@ -1,0 +1,37 @@
+package com.susu.core.designsystem.component.textfield
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+import java.text.DecimalFormat
+
+class PriceVisualTransformation : VisualTransformation {
+    override fun filter(text: AnnotatedString): TransformedText {
+        val amount = text.text
+        val formatAmount = if (amount.isEmpty()) "" else DecimalFormat("#,###").format(amount.toLong())
+
+        return TransformedText(
+            text = AnnotatedString("${formatAmount}원"),
+            offsetMapping = object : OffsetMapping {
+                override fun originalToTransformed(offset: Int): Int {
+                    if (offset <= 1) return offset
+
+                    val entireCommaCount = if (amount.length % 3 == 0) amount.length / 3 - 1 else amount.length / 3
+                    val commaBeforeOffsetCount = formatAmount.substring(0 until offset + entireCommaCount).count { it == ',' }
+
+                    return offset + commaBeforeOffsetCount
+                }
+
+                override fun transformedToOriginal(offset: Int): Int {
+                    if (offset <= 1) return offset
+
+                    val entireCommaCount = if (amount.length % 3 == 0) amount.length / 3 - 1 else amount.length / 3
+                    val commaBeforeOffsetCount = formatAmount.substring(0 until offset + entireCommaCount).count { it == ',' }
+
+                    return offset - commaBeforeOffsetCount
+                }
+            },
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/PriceVisualTransformation.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/PriceVisualTransformation.kt
@@ -9,7 +9,7 @@ import java.text.DecimalFormat
 class PriceVisualTransformation : VisualTransformation {
     override fun filter(text: AnnotatedString): TransformedText {
         val amount = text.text
-        val formatAmount = if (amount.isEmpty()) "" else DecimalFormat("#,###").format(amount.toLong())
+        val formatAmount = if (amount.isEmpty()) "" else DecimalFormat("#,###").format(amount.toBigDecimal())
 
         return TransformedText(
             text = AnnotatedString("${formatAmount}원"),

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuTextField.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuTextField.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import com.susu.core.designsystem.theme.Gray100
@@ -72,15 +73,54 @@ fun SusuBasicTextField(
 }
 
 @Composable
+fun SusuPriceTextField(
+    modifier: Modifier = Modifier,
+    text: String = "",
+    onTextChange: (String) -> Unit = {},
+    placeholder: String = "",
+    color: SusuTextFieldColor = SusuTextFieldColor.Default,
+    enabled: Boolean = true,
+    textStyle: TextStyle = SusuTheme.typography.title_xl,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    maxLines: Int = 1,
+    minLines: Int = 1,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    cursorBrush: Brush = SolidColor(Color.Black),
+) {
+    SusuBasicTextField(
+        modifier = modifier,
+        text = text,
+        onTextChange = onTextChange,
+        placeholder = placeholder,
+        color = color,
+        enabled = enabled,
+        textStyle = textStyle,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        keyboardActions = keyboardActions,
+        maxLines = maxLines,
+        minLines = minLines,
+        interactionSource = interactionSource,
+        cursorBrush = cursorBrush,
+        visualTransformation = PriceVisualTransformation(),
+    )
+}
+
+@Composable
 @Preview
 fun SusuBasicTextFieldPreview() {
     SusuTheme {
         var text by remember { mutableStateOf("") }
+        var price by remember { mutableStateOf("") }
         Column {
             SusuBasicTextField(
                 text = text,
                 onTextChange = { text = it },
                 placeholder = "이름을 입력해주세요",
+            )
+            SusuPriceTextField(
+                text = price,
+                onTextChange = { price = it },
+                placeholder = "금액을 입력해주세요",
             )
         }
     }

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuTextField.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuTextField.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
@@ -83,7 +83,7 @@ fun SusuPriceTextField(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     cursorBrush: Brush = SolidColor(Color.Black),
 ) {
-    val moneyUnitString = LocalContext.current.resources.getString(R.string.money_unit)
+    val moneyUnitString = stringResource(R.string.money_unit)
     SusuBasicTextField(
         modifier = modifier,
         text = text,

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuTextField.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuTextField.kt
@@ -15,10 +15,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
+import com.susu.core.designsystem.R
 import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.Gray40
 import com.susu.core.designsystem.theme.SusuTheme
@@ -81,6 +83,7 @@ fun SusuPriceTextField(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     cursorBrush: Brush = SolidColor(Color.Black),
 ) {
+    val moneyUnitString = LocalContext.current.resources.getString(R.string.money_unit)
     SusuBasicTextField(
         modifier = modifier,
         text = text,
@@ -96,7 +99,7 @@ fun SusuPriceTextField(
         minLines = minLines,
         interactionSource = interactionSource,
         cursorBrush = cursorBrush,
-        visualTransformation = PriceVisualTransformation(),
+        visualTransformation = PriceVisualTransformation(postfix = moneyUnitString),
     )
 }
 

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuTextField.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuTextField.kt
@@ -23,20 +23,14 @@ import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.Gray40
 import com.susu.core.designsystem.theme.SusuTheme
 
-enum class SusuTextFieldColor(
-    val textColor: Color,
-    val placeholderColor: Color,
-) {
-    Default(textColor = Gray100, placeholderColor = Gray40),
-}
-
 @Composable
 fun SusuBasicTextField(
     modifier: Modifier = Modifier,
     text: String = "",
     onTextChange: (String) -> Unit = {},
     placeholder: String = "",
-    color: SusuTextFieldColor = SusuTextFieldColor.Default,
+    textColor: Color = Gray100,
+    placeholderColor: Color = Gray40,
     enabled: Boolean = true,
     textStyle: TextStyle = SusuTheme.typography.title_xl,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
@@ -52,7 +46,7 @@ fun SusuBasicTextField(
         value = text,
         onValueChange = onTextChange,
         enabled = enabled,
-        textStyle = textStyle.copy(color = color.textColor),
+        textStyle = textStyle.copy(color = textColor),
         keyboardActions = keyboardActions,
         keyboardOptions = keyboardOptions,
         maxLines = maxLines,
@@ -64,7 +58,7 @@ fun SusuBasicTextField(
         if (text.isEmpty()) {
             Text(
                 text = placeholder,
-                style = textStyle.copy(color = color.placeholderColor),
+                style = textStyle.copy(color = placeholderColor),
             )
         } else {
             innerTextField()
@@ -78,7 +72,8 @@ fun SusuPriceTextField(
     text: String = "",
     onTextChange: (String) -> Unit = {},
     placeholder: String = "",
-    color: SusuTextFieldColor = SusuTextFieldColor.Default,
+    textColor: Color = Gray100,
+    placeholderColor: Color = Gray40,
     enabled: Boolean = true,
     textStyle: TextStyle = SusuTheme.typography.title_xl,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
@@ -92,7 +87,8 @@ fun SusuPriceTextField(
         text = text,
         onTextChange = onTextChange,
         placeholder = placeholder,
-        color = color,
+        textColor = textColor,
+        placeholderColor = placeholderColor,
         enabled = enabled,
         textStyle = textStyle,
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuTextField.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuTextField.kt
@@ -60,9 +60,8 @@ fun SusuBasicTextField(
                 text = placeholder,
                 style = textStyle.copy(color = placeholderColor),
             )
-        } else {
-            innerTextField()
         }
+        innerTextField()
     }
 }
 

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuTextField.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuTextField.kt
@@ -1,0 +1,87 @@
+package com.susu.core.designsystem.component.textfield
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import com.susu.core.designsystem.theme.Gray100
+import com.susu.core.designsystem.theme.Gray40
+import com.susu.core.designsystem.theme.SusuTheme
+
+enum class SusuTextFieldColor(
+    val textColor: Color,
+    val placeholderColor: Color,
+) {
+    Default(textColor = Gray100, placeholderColor = Gray40),
+}
+
+@Composable
+fun SusuBasicTextField(
+    modifier: Modifier = Modifier,
+    text: String = "",
+    onTextChange: (String) -> Unit = {},
+    placeholder: String = "",
+    color: SusuTextFieldColor = SusuTextFieldColor.Default,
+    enabled: Boolean = true,
+    textStyle: TextStyle = SusuTheme.typography.title_xl,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    maxLines: Int = 1,
+    minLines: Int = 1,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    cursorBrush: Brush = SolidColor(Color.Black),
+) {
+    BasicTextField(
+        modifier = modifier,
+        value = text,
+        onValueChange = onTextChange,
+        enabled = enabled,
+        textStyle = textStyle.copy(color = color.textColor),
+        keyboardActions = keyboardActions,
+        keyboardOptions = keyboardOptions,
+        maxLines = maxLines,
+        minLines = minLines,
+        visualTransformation = visualTransformation,
+        interactionSource = interactionSource,
+        cursorBrush = cursorBrush,
+    ) { innerTextField ->
+        if (text.isEmpty()) {
+            Text(
+                text = placeholder,
+                style = textStyle.copy(color = color.placeholderColor),
+            )
+        } else {
+            innerTextField()
+        }
+    }
+}
+
+@Composable
+@Preview
+fun SusuBasicTextFieldPreview() {
+    SusuTheme {
+        var text by remember { mutableStateOf("") }
+        Column {
+            SusuBasicTextField(
+                text = text,
+                onTextChange = { text = it },
+                placeholder = "이름을 입력해주세요",
+            )
+        }
+    }
+}

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuUnderlineTextField.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuUnderlineTextField.kt
@@ -40,7 +40,7 @@ enum class SusuUnderlineTextFieldColor(
     val limitationColor: Color,
     val descriptionColor: Color,
 ) {
-    Unactive(
+    Inactive(
         textColor = Gray30,
         underlineColor = Gray50,
         limitationColor = Gray30,
@@ -94,14 +94,10 @@ fun SusuUnderlineTextField(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     cursorBrush: Brush = SolidColor(Color.Black),
 ) {
-    val textFieldColor = if (isError) {
-        SusuUnderlineTextFieldColor.Error
-    } else {
-        if (text.isEmpty()) {
-            SusuUnderlineTextFieldColor.Unactive
-        } else {
-            SusuUnderlineTextFieldColor.Active
-        }
+    val textFieldColor = when {
+        isError -> SusuUnderlineTextFieldColor.Error
+        text.isEmpty() -> SusuUnderlineTextFieldColor.Inactive
+        else -> SusuUnderlineTextFieldColor.Active
     }
 
     with(textStyle()) {

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuUnderlineTextField.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuUnderlineTextField.kt
@@ -1,0 +1,176 @@
+package com.susu.core.designsystem.component.textfield
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.susu.core.designsystem.component.util.ClearIconButton
+import com.susu.core.designsystem.theme.Gray100
+import com.susu.core.designsystem.theme.Gray30
+import com.susu.core.designsystem.theme.Gray50
+import com.susu.core.designsystem.theme.Red60
+import com.susu.core.designsystem.theme.SusuTheme
+
+enum class SusuUnderlineTextFieldColor(
+    val textColor: Color,
+    val underlineColor: Color,
+    val limitationColor: Color,
+    val descriptionColor: Color,
+) {
+    Unactive(
+        textColor = Gray30,
+        underlineColor = Gray50,
+        limitationColor = Gray30,
+        descriptionColor = Color.Unspecified,
+    ),
+    Active(
+        textColor = Gray100,
+        underlineColor = Gray100,
+        limitationColor = Gray30,
+        descriptionColor = Color.Unspecified,
+    ),
+    Error(
+        textColor = Gray100,
+        underlineColor = Red60,
+        limitationColor = Red60,
+        descriptionColor = Red60,
+    ),
+}
+
+data class SusuUnderlineTextFieldTextStyle(
+    val contentTextStyle: TextStyle,
+    val limitationTextStyle: TextStyle,
+    val descriptionTextStyle: TextStyle,
+)
+
+object SusuUnderlineTextFieldDefault {
+    val textStyle: @Composable () -> SusuUnderlineTextFieldTextStyle = {
+        SusuUnderlineTextFieldTextStyle(
+            contentTextStyle = SusuTheme.typography.title_l,
+            limitationTextStyle = SusuTheme.typography.title_xs,
+            descriptionTextStyle = SusuTheme.typography.text_xxs,
+        )
+    }
+}
+
+@Composable
+fun SusuUnderlineTextField(
+    modifier: Modifier = Modifier,
+    text: String = "",
+    onTextChange: (String) -> Unit = {},
+    placeholder: String = "",
+    placeholderColor: Color = Gray30,
+    description: String = "",
+    isError: Boolean = false,
+    lengthLimit: Int = 20,
+    onClickClearIcon: () -> Unit = {},
+    textStyle: @Composable () -> SusuUnderlineTextFieldTextStyle = SusuUnderlineTextFieldDefault.textStyle,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    cursorBrush: Brush = SolidColor(Color.Black),
+) {
+    val textFieldColor = if (isError) SusuUnderlineTextFieldColor.Error else {
+        if (text.isEmpty()) {
+            SusuUnderlineTextFieldColor.Unactive
+        } else {
+            SusuUnderlineTextFieldColor.Active
+        }
+    }
+
+    with(textStyle()) {
+        Column(
+            modifier = modifier,
+            verticalArrangement = Arrangement.spacedBy(SusuTheme.spacing.spacing_s),
+        ) {
+            Row(
+                modifier = Modifier
+                    .drawBehind {
+                        drawLine(
+                            color = textFieldColor.underlineColor,
+                            start = Offset(0f, size.height),
+                            end = Offset(size.width, size.height),
+                            strokeWidth = 1f,
+                        )
+                    }
+                    .padding(SusuTheme.spacing.spacing_xxs),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                SusuBasicTextField(
+                    modifier = Modifier.weight(1f),
+                    text = text,
+                    textColor = textFieldColor.textColor,
+                    onTextChange = onTextChange,
+                    placeholder = placeholder,
+                    placeholderColor = placeholderColor,
+                    textStyle = contentTextStyle,
+                    keyboardActions = keyboardActions,
+                    keyboardOptions = keyboardOptions,
+                    visualTransformation = visualTransformation,
+                    interactionSource = interactionSource,
+                    cursorBrush = cursorBrush,
+                )
+                if (text.isNotEmpty()) {
+                    Box(modifier = Modifier.padding(horizontal = SusuTheme.spacing.spacing_s)) {
+                        ClearIconButton(iconSize = 24.dp, onClick = onClickClearIcon)
+                    }
+                } else {
+                    Spacer(modifier = Modifier.width(SusuTheme.spacing.spacing_xxs))
+                }
+                Text(
+                    text = "${text.length}/$lengthLimit",
+                    style = limitationTextStyle.copy(color = textFieldColor.limitationColor),
+                )
+            }
+            if (description.isNotEmpty()) {
+                Text(text = description, style = descriptionTextStyle.copy(color = textFieldColor.descriptionColor))
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun SusuUnderlineTextFieldPreview() {
+    SusuTheme {
+        var text by remember { mutableStateOf("") }
+        Column {
+            SusuUnderlineTextField(
+                text = text,
+                onTextChange = { text = it },
+                placeholder = "김수수",
+            )
+            SusuUnderlineTextField(
+                text = text,
+                onTextChange = { text = it },
+                placeholder = "김수수",
+                isError = true,
+                description = "에러 메세지를 입력하세요",
+            )
+        }
+    }
+}

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuUnderlineTextField.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuUnderlineTextField.kt
@@ -83,7 +83,7 @@ fun SusuUnderlineTextField(
     onTextChange: (String) -> Unit = {},
     placeholder: String = "",
     placeholderColor: Color = Gray30,
-    description: String = "",
+    description: String? = null,
     isError: Boolean = false,
     lengthLimit: Int = 20,
     onClickClearIcon: () -> Unit = {},
@@ -148,8 +148,8 @@ fun SusuUnderlineTextField(
                     style = limitationTextStyle.copy(color = textFieldColor.limitationColor),
                 )
             }
-            if (description.isNotEmpty()) {
-                Text(text = description, style = descriptionTextStyle.copy(color = textFieldColor.descriptionColor))
+            description?.let { descriptionText ->
+                Text(text = descriptionText, style = descriptionTextStyle.copy(color = textFieldColor.descriptionColor))
             }
         }
     }

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuUnderlineTextField.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuUnderlineTextField.kt
@@ -94,7 +94,9 @@ fun SusuUnderlineTextField(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     cursorBrush: Brush = SolidColor(Color.Black),
 ) {
-    val textFieldColor = if (isError) SusuUnderlineTextFieldColor.Error else {
+    val textFieldColor = if (isError) {
+        SusuUnderlineTextFieldColor.Error
+    } else {
         if (text.isEmpty()) {
             SusuUnderlineTextFieldColor.Unactive
         } else {

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfieldbutton/SusuTextFieldButton.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfieldbutton/SusuTextFieldButton.kt
@@ -297,7 +297,7 @@ private fun InnerButtons(
             if (showClearIcon) {
                 ClearIconButton(
                     iconSize = clearIconSize,
-                    onClick = onClickClearIcon
+                    onClick = onClickClearIcon,
                 )
             }
         }

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfieldbutton/SusuTextFieldButton.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfieldbutton/SusuTextFieldButton.kt
@@ -42,6 +42,7 @@ import com.susu.core.designsystem.component.textfieldbutton.style.InnerButtonSty
 import com.susu.core.designsystem.component.textfieldbutton.style.LargeTextFieldButtonStyle
 import com.susu.core.designsystem.component.textfieldbutton.style.SmallTextFieldButtonStyle
 import com.susu.core.designsystem.component.textfieldbutton.style.TextFieldButtonStyle
+import com.susu.core.designsystem.component.util.ClearIconButton
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.ui.extension.disabledHorizontalPointerInputScroll
 import com.susu.core.ui.extension.susuClickable
@@ -294,13 +295,9 @@ private fun InnerButtons(
     if (isSaved.not()) {
         Box(modifier = Modifier.size(clearIconSize)) {
             if (showClearIcon) {
-                Image(
-                    modifier = Modifier
-                        .clip(CircleShape)
-                        .size(clearIconSize)
-                        .susuClickable(onClick = onClickClearIcon),
-                    painter = painterResource(id = R.drawable.ic_clear),
-                    contentDescription = "",
+                ClearIconButton(
+                    iconSize = clearIconSize,
+                    onClick = onClickClearIcon
                 )
             }
         }

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/util/ClearIconButton.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/util/ClearIconButton.kt
@@ -1,0 +1,27 @@
+package com.susu.core.designsystem.component.util
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
+import com.susu.core.designsystem.R
+import com.susu.core.ui.extension.susuClickable
+
+@Composable
+fun ClearIconButton(
+    iconSize: Dp,
+    onClick: () -> Unit,
+) {
+    Image(
+        modifier = Modifier
+            .clip(CircleShape)
+            .size(iconSize)
+            .susuClickable(onClick = onClick),
+        painter = painterResource(id = R.drawable.ic_clear),
+        contentDescription = "",
+    )
+}

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -2,4 +2,6 @@
 <resources>
     <string name="word_edit">편집</string>
     <string name="word_save">저장</string>
+    <string name="money_unit">원</string>
+    <string name="money_unit_format">%s원</string>
 </resources>


### PR DESCRIPTION
## 💡 Issue
- Resolved: #27 

## 🌱 Key changes
- `SusuBasicTextField`: 기본이 되는 TextField
- `SusuPriceTextField`:  `SusuBasicTextField`에 `VisualTransformation`을 적용
- `SusuUnderlineTextField`: `SusuBasicTextField`을 활용하여 구현

## ✅ To Reviewers
<img width="59" alt="스크린샷 2024-01-04 오전 2 13 52" src="https://github.com/YAPP-Github/oksusu-susu-android/assets/69582122/bc9ae6c5-2429-46de-b02d-b6fc527b9b9f">

- TextFieldButton과 공유하는 clearIconButton을 분리해서 재사용했습니다.
- SusuPriceTextField에 매우매우 큰 숫자를 입력하면 터집니다만...
    - PriceVisualTransformation에서 방지하기 위해 Long.MAX_VALUE를 기준으로 제한해봤는데, 간결히 말하면 Format된 문자열 계산하는 과정에서 오류가 발생해서 롤백했습니다
    - 데이터 정의 상 금액 단위가 int이고, int 최대 범위보다 넉넉하게 입력 가능합니다.
        - 21억이 넘는 돈을 경조사비로 주고 받는건 이재용 회장님밖에 없지 않을까요?


## 📸 스크린샷
|SusuTextField|SusuUnderlineTextField|
|:--:|:--:|
|![textfield](https://github.com/YAPP-Github/oksusu-susu-android/assets/69582122/11b62d81-8322-4a5e-b1cf-d2cb6bfa707d)|![underlineTextfield](https://github.com/YAPP-Github/oksusu-susu-android/assets/69582122/c1720a15-0bcb-4f65-94f5-27d1ab5b6c79)|

