### PR TITLE
Hotfix/refresh-token 토큰 만료시 갱신하지 못하는 현상

### DIFF
--- a/core/model/src/main/java/com/susu/core/model/exception/CommonExceptions.kt
+++ b/core/model/src/main/java/com/susu/core/model/exception/CommonExceptions.kt
@@ -1,7 +1,5 @@
 package com.susu.core.model.exception
 
-import java.io.IOException
-
 class RequestFailException(
     override val message: String = "요청을 처리하지 못했어요.",
 ) : RuntimeException()
@@ -21,7 +19,3 @@ class NetworkException(
 class UnknownException(
     override val message: String = "알 수 없는 에러가 발생했어요.",
 ) : RuntimeException()
-
-class RefreshTokenExpiredException(
-    override val message: String = "다시 로그인 해주세요."
-) : IOException()

--- a/core/model/src/main/java/com/susu/core/model/exception/CommonExceptions.kt
+++ b/core/model/src/main/java/com/susu/core/model/exception/CommonExceptions.kt
@@ -1,5 +1,7 @@
 package com.susu.core.model.exception
 
+import java.io.IOException
+
 class RequestFailException(
     override val message: String = "요청을 처리하지 못했어요.",
 ) : RuntimeException()
@@ -19,3 +21,7 @@ class NetworkException(
 class UnknownException(
     override val message: String = "알 수 없는 에러가 발생했어요.",
 ) : RuntimeException()
+
+class RefreshTokenExpiredException(
+    override val message: String = "다시 로그인 해주세요."
+) : IOException()

--- a/data/src/main/java/com/susu/data/model/request/RefreshTokenRequest.kt
+++ b/data/src/main/java/com/susu/data/model/request/RefreshTokenRequest.kt
@@ -4,5 +4,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class RefreshTokenRequest(
+    val accessToken: String,
     val refreshToken: String,
 )

--- a/data/src/main/java/com/susu/data/network/TokenAuthenticator.kt
+++ b/data/src/main/java/com/susu/data/network/TokenAuthenticator.kt
@@ -21,7 +21,6 @@ class TokenAuthenticator @Inject constructor(
         val accessToken = runBlocking { tokenRepository.getAccessToken().firstOrNull() }
 
         if (refreshToken == null || accessToken == null) {
-            response.close()
             return null
         }
 
@@ -35,7 +34,6 @@ class TokenAuthenticator @Inject constructor(
             if (tokenResponse.isSuccessful.not() || tokenResponse.body() == null) {
                 // 삭제하여 다시 로그인하도록 유도
                 tokenRepository.deleteTokens()
-                response.close()
                 null
             } else {
                 // 3. 헤더에 토큰을 교체한 request 생성

--- a/data/src/main/java/com/susu/data/network/TokenInterceptor.kt
+++ b/data/src/main/java/com/susu/data/network/TokenInterceptor.kt
@@ -1,12 +1,10 @@
 package com.susu.data.network
 
-import com.susu.core.model.exception.RefreshTokenExpiredException
 import com.susu.domain.repository.TokenRepository
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Response
-import java.io.IOException
 import javax.inject.Inject
 
 class TokenInterceptor @Inject constructor(
@@ -17,13 +15,9 @@ class TokenInterceptor @Inject constructor(
             tokenRepository.getAccessToken().firstOrNull()
         }
 
-        return try {
-            val request = chain.request().newBuilder().apply {
-                addHeader("X-SUSU-AUTH-TOKEN", token ?: "")
-            }
-            chain.proceed(request.build())
-        } catch (e: Exception) {
-            throw RefreshTokenExpiredException()
+        val request = chain.request().newBuilder().apply {
+            addHeader("X-SUSU-AUTH-TOKEN", token ?: "")
         }
+        return chain.proceed(request.build())
     }
 }


### PR DESCRIPTION
## 🌱 Key changes
- `RefreshTokenRequest` 수정
- `TokenInterceptor`에서 Exception을 throw 하도록 수정

## ✅ To Reviewers
- AccessToken 만료 후 재발급
    -  백엔드 로직 변경으로 `RefreshTokenRequest`에 `accessToken`이 추가되었습니다.
- RefreshToken 만료
    - `TokenAuthenticator`는 refresh token이 만료되었을 때 response를 close하여 다시 `authenticate()`를 호출하지 않도록 하고 있습니다.
    - `TokenInterceptor`에서 이미 response가 close되어 있어 Exception이 발생합니다. 
    - Okhttp Interceptor는 [IOException이 아닌 Exception을 호출부로 던지지 않고 그대로 자폭](https://stackoverflow.com/questions/58697459/handle-exceptions-thrown-by-a-custom-okhttp-interceptor-in-kotlin-coroutines)하는 성질을 가지고 있습니다.
    -  그래서 `IOException`을 상속받는 `RefreshTokenExpiredException`을 만들었고, UseCase의 runCatching에서 Exception이 잡힙니다
        - `RefreshTokenExpiredException`의 경우에는 로그인 화면으로 이동하는 동작을 해야 합니다. 




