### PR TITLE
Feature/mz 172 장부 편집 화면 UI, status bar 색상

### DIFF
--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/button/AddConditionButton.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/button/AddConditionButton.kt
@@ -1,0 +1,43 @@
+package com.susu.core.designsystem.component.button
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.susu.core.designsystem.R
+import com.susu.core.designsystem.theme.Gray25
+import com.susu.core.designsystem.theme.Gray70
+import com.susu.core.designsystem.theme.SusuTheme
+
+@Composable
+fun AddConditionButton(
+    onClick: () -> Unit,
+) {
+    BasicButton(
+        padding = PaddingValues(SusuTheme.spacing.spacing_xxxxs),
+        backgroundColor = Gray25,
+        shape = RoundedCornerShape(4.dp),
+        leftIcon = {
+            Icon(
+                painter = painterResource(
+                    id = com.susu.core.ui.R.drawable.ic_add,
+                ),
+                contentDescription = stringResource(com.susu.core.ui.R.string.content_description_add_button),
+                tint = Gray70,
+            )
+        },
+    )
+}
+
+@Preview
+@Composable
+fun AddConditionButtonPreview() {
+    SusuTheme {
+        AddConditionButton {
+        }
+    }
+}

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/button/AddConditionButton.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/button/AddConditionButton.kt
@@ -30,6 +30,7 @@ fun AddConditionButton(
                 tint = Gray70,
             )
         },
+        onClick = onClick,
     )
 }
 

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfieldbutton/SusuTextFieldButton.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfieldbutton/SusuTextFieldButton.kt
@@ -320,7 +320,7 @@ private fun InnerButtons(
                 .padding(paddingValues),
         ) {
             Text(
-                text = if (isSaved) stringResource(R.string.word_edit) else stringResource(R.string.word_save),
+                text = if (isSaved) stringResource(com.susu.core.ui.R.string.word_edit) else stringResource(com.susu.core.ui.R.string.word_save),
                 style = textStyle,
                 color = innerButtonTextColor,
             )

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="word_edit">편집</string>
-    <string name="word_save">저장</string>
     <string name="money_unit">원</string>
     <string name="money_unit_format">%s원</string>
     <string name="content_description_search_icon">검색 아이콘</string>

--- a/core/ui/src/main/java/com/susu/core/ui/util/AnnotatedText.kt
+++ b/core/ui/src/main/java/com/susu/core/ui/util/AnnotatedText.kt
@@ -1,0 +1,32 @@
+package com.susu.core.ui.util
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+
+@Composable
+fun AnnotatedText(
+    modifier: Modifier = Modifier,
+    originalText: String,
+    originalTextStyle: TextStyle,
+    targetTextList: List<String>,
+    spanStyle: SpanStyle,
+) {
+    val annotatedString = buildAnnotatedString {
+        append(originalText)
+
+        targetTextList.forEach { targetText ->
+            val startIndex = originalText.indexOf(targetText)
+            val endIndex = startIndex + targetText.length
+            addStyle(style = spanStyle, start = startIndex, end = endIndex)
+        }
+    }
+    Text(
+        modifier = modifier,
+        style = originalTextStyle,
+        text = annotatedString,
+    )
+}

--- a/core/ui/src/main/res/drawable/ic_add.xml
+++ b/core/ui/src/main/res/drawable/ic_add.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+      android:fillColor="#828282"/>
+</vector>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -14,4 +14,7 @@
     <string name="word_event_category">경조사 카테고리</string>
     <string name="word_event_range">경조사 기간</string>
     <string name="word_filter">필터</string>
+    <string name="word_category">카테고리</string>
+    <string name="word_date">날짜</string>
+    <string name="content_description_add_button">더하기 버튼</string>
 </resources>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="word_align_low_amount">금액 낮은 순</string>
     <string name="word_recent_search">최근 검색</string>
     <string name="word_edit">편집</string>
+    <string name="word_save">저장</string>
     <string name="word_delete">삭제</string>
     <string name="word_total_money">전체 %s원</string>
     <string name="word_total_count">총 %d개</string>

--- a/feature/navigator/build.gradle.kts
+++ b/feature/navigator/build.gradle.kts
@@ -16,4 +16,5 @@ dependencies {
     implementation(projects.feature.statistics)
 
     implementation(libs.androidx.splashscreen)
+    implementation(libs.compose.accompanist.systemuicontroller)
 }

--- a/feature/navigator/src/main/java/com/susu/feature/navigator/MainNavigator.kt
+++ b/feature/navigator/src/main/java/com/susu/feature/navigator/MainNavigator.kt
@@ -2,15 +2,20 @@ package com.susu.feature.navigator
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
 import androidx.navigation.NavDestination
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
+import com.susu.core.designsystem.theme.Gray10
+import com.susu.core.designsystem.theme.Gray100
+import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.feature.community.navigation.navigateCommunity
 import com.susu.feature.loginsignup.navigation.LoginSignupRoute
 import com.susu.feature.mypage.navigation.navigateMyPage
+import com.susu.feature.received.navigation.ReceivedRoute
 import com.susu.feature.received.navigation.navigateLedgerDetail
 import com.susu.feature.received.navigation.navigateLedgerEdit
 import com.susu.feature.received.navigation.navigateLedgerSearch
@@ -31,6 +36,13 @@ internal class MainNavigator(
         @Composable get() = currentDestination
             ?.route
             ?.let(MainNavigationTab::find)
+
+    val statusBarColor: Color
+        @Composable
+        get() = when (currentDestination?.route) {
+            in listOf(ReceivedRoute.ledgerSearchRoute) -> SusuTheme.colorScheme.background10
+            else -> SusuTheme.colorScheme.background15
+        }
 
     fun navigate(tab: MainNavigationTab) {
         val navOptions = navOptions {

--- a/feature/navigator/src/main/java/com/susu/feature/navigator/MainNavigator.kt
+++ b/feature/navigator/src/main/java/com/susu/feature/navigator/MainNavigator.kt
@@ -9,8 +9,6 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
-import com.susu.core.designsystem.theme.Gray10
-import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.feature.community.navigation.navigateCommunity
 import com.susu.feature.loginsignup.navigation.LoginSignupRoute

--- a/feature/navigator/src/main/java/com/susu/feature/navigator/MainNavigator.kt
+++ b/feature/navigator/src/main/java/com/susu/feature/navigator/MainNavigator.kt
@@ -12,6 +12,7 @@ import com.susu.feature.community.navigation.navigateCommunity
 import com.susu.feature.loginsignup.navigation.LoginSignupRoute
 import com.susu.feature.mypage.navigation.navigateMyPage
 import com.susu.feature.received.navigation.navigateLedgerDetail
+import com.susu.feature.received.navigation.navigateLedgerEdit
 import com.susu.feature.received.navigation.navigateLedgerSearch
 import com.susu.feature.received.navigation.navigateReceived
 import com.susu.feature.sent.navigation.SentRoute
@@ -75,6 +76,10 @@ internal class MainNavigator(
 
     fun navigateLedgerSearch() {
         navController.navigateLedgerSearch()
+    }
+
+    fun navigateLedgerEdit() {
+        navController.navigateLedgerEdit()
     }
 
     fun popBackStackIfNotHome() {

--- a/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
+++ b/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.susu.core.designsystem.component.navigation.SusuNavigationBar
 import com.susu.core.designsystem.component.navigation.SusuNavigationItem
 import com.susu.core.designsystem.component.snackbar.SusuSnackbar
@@ -40,6 +41,9 @@ internal fun MainScreen(
             MainSideEffect.NavigateSignup -> navigator.navigateSignup()
         }
     }
+
+    val systemUiController = rememberSystemUiController()
+    systemUiController.setStatusBarColor(color = navigator.statusBarColor, darkIcons = true)
 
     Scaffold(
         modifier = modifier,

--- a/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
+++ b/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
@@ -62,6 +62,7 @@ internal fun MainScreen(
                     popBackStack = navigator::popBackStackIfNotHome,
                     navigateLedgerSearch = navigator::navigateLedgerSearch,
                     navigateLedgerDetail = navigator::navigateLedgerDetail,
+                    navigateLedgerEdit = navigator::navigateLedgerEdit,
                 )
 
                 statisticsNavGraph(

--- a/feature/received/src/main/java/com/susu/feature/received/ledgerdetail/LedgerDetailScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgerdetail/LedgerDetailScreen.kt
@@ -42,8 +42,11 @@ import com.susu.feature.received.ledgerdetail.component.LedgerDetailOverviewColu
 fun LedgerDetailRoute(
     @Suppress("deteKt:UnusedParameter")
     viewModel: LedgerDetailViewModel = hiltViewModel(),
+    navigateLedgerEdit: () -> Unit,
 ) {
-    LedgerDetailScreen()
+    LedgerDetailScreen(
+        onClickEdit = navigateLedgerEdit,
+    )
 }
 
 @Composable

--- a/feature/received/src/main/java/com/susu/feature/received/ledgerdetail/LedgerDetailScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgerdetail/LedgerDetailScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -120,6 +121,7 @@ fun LedgerDetailScreen(
                             text = stringResource(R.string.word_filter),
                             leftIcon = {
                                 Icon(
+                                    modifier = Modifier.size(16.dp),
                                     painter = painterResource(id = R.drawable.ic_filter),
                                     contentDescription = null,
                                 )

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeredit/LedgerEditScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeredit/LedgerEditScreen.kt
@@ -2,17 +2,21 @@ package com.susu.feature.received.ledgeredit
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -20,6 +24,7 @@ import com.susu.core.designsystem.component.appbar.SusuDefaultAppBar
 import com.susu.core.designsystem.component.appbar.icon.BackIcon
 import com.susu.core.designsystem.component.button.AddConditionButton
 import com.susu.core.designsystem.component.button.FilledButtonColor
+import com.susu.core.designsystem.component.button.MediumButtonStyle
 import com.susu.core.designsystem.component.button.SmallButtonStyle
 import com.susu.core.designsystem.component.button.SusuFilledButton
 import com.susu.core.designsystem.component.textfieldbutton.SusuTextFieldWrapContentButton
@@ -42,107 +47,124 @@ fun LedgerEditRoute(
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun LedgerEditScreen() {
-    Column(
+    Box(
         modifier = Modifier
             .background(SusuTheme.colorScheme.background15)
             .fillMaxSize(),
     ) {
-        SusuDefaultAppBar(
-            leftIcon = {
-                BackIcon()
-            },
-        )
-
-        Spacer(modifier = Modifier.size(23.dp))
-
         Column(
             modifier = Modifier
-                .padding(horizontal = SusuTheme.spacing.spacing_m),
+                .background(SusuTheme.colorScheme.background15)
+                .fillMaxSize(),
         ) {
-            LedgerEditContainer(
-                name = stringResource(id = com.susu.core.ui.R.string.word_event_name),
-                verticalAlignment = Alignment.CenterVertically,
-                content = {
-                    Text(
-                        text = "고모부 장례식",
-                        style = SusuTheme.typography.title_m,
-                    )
+            SusuDefaultAppBar(
+                leftIcon = {
+                    BackIcon()
                 },
             )
 
-            LedgerEditContainer(
-                name = stringResource(id = com.susu.core.ui.R.string.word_category),
-                verticalAlignment = Alignment.Top,
-                content = {
-                    FlowRow(
-                        verticalArrangement = Arrangement.spacedBy(SusuTheme.spacing.spacing_xxs),
-                        horizontalArrangement = Arrangement.spacedBy(SusuTheme.spacing.spacing_xxs),
-                    ) {
-                        SusuFilledButton(
-                            color = FilledButtonColor.Orange,
-                            style = SmallButtonStyle.height32,
-                            text = "결혼식",
-                        )
+            Spacer(modifier = Modifier.size(23.dp))
 
-                        SusuFilledButton(
-                            color = FilledButtonColor.Orange,
-                            style = SmallButtonStyle.height32,
-                            text = "돌잔치",
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = SusuTheme.spacing.spacing_m),
+            ) {
+                LedgerEditContainer(
+                    name = stringResource(id = com.susu.core.ui.R.string.word_event_name),
+                    verticalAlignment = Alignment.CenterVertically,
+                    content = {
+                        Text(
+                            text = "고모부 장례식",
+                            style = SusuTheme.typography.title_m,
                         )
+                    },
+                )
 
-                        SusuFilledButton(
-                            color = FilledButtonColor.Orange,
-                            style = SmallButtonStyle.height32,
-                            text = "장례식",
-                        )
+                LedgerEditContainer(
+                    name = stringResource(id = com.susu.core.ui.R.string.word_category),
+                    verticalAlignment = Alignment.Top,
+                    content = {
+                        FlowRow(
+                            verticalArrangement = Arrangement.spacedBy(SusuTheme.spacing.spacing_xxs),
+                            horizontalArrangement = Arrangement.spacedBy(SusuTheme.spacing.spacing_xxs),
+                        ) {
+                            SusuFilledButton(
+                                color = FilledButtonColor.Orange,
+                                style = SmallButtonStyle.height32,
+                                text = "결혼식",
+                            )
 
-                        SusuFilledButton(
-                            color = FilledButtonColor.Orange,
-                            style = SmallButtonStyle.height32,
-                            text = "생일 기념일",
-                        )
+                            SusuFilledButton(
+                                color = FilledButtonColor.Orange,
+                                style = SmallButtonStyle.height32,
+                                text = "돌잔치",
+                            )
 
-                        AddConditionButton(onClick = {})
+                            SusuFilledButton(
+                                color = FilledButtonColor.Orange,
+                                style = SmallButtonStyle.height32,
+                                text = "장례식",
+                            )
 
-                        SusuTextFieldWrapContentButton(
-                            color = TextFieldButtonColor.Orange,
-                            style = SmallTextFieldButtonStyle.height32,
-                            text = "친척 장례식",
-                            isSaved = true,
-                        )
-                    }
-                },
-            )
+                            SusuFilledButton(
+                                color = FilledButtonColor.Orange,
+                                style = SmallButtonStyle.height32,
+                                text = "생일 기념일",
+                            )
 
-            LedgerEditContainer(
-                name = stringResource(com.susu.core.ui.R.string.word_date),
-                verticalAlignment = Alignment.Top,
-                content = {
-                    Column {
-                        AnnotatedText(
-                            originalText = stringResource(R.string.ledger_edit_screen_from_date, 2023, 11, 25),
-                            targetTextList = listOf(
-                                stringResource(R.string.ledger_edit_screen_year),
-                                stringResource(R.string.ledger_edit_screen_month),
-                                stringResource(R.string.ledger_edit_screen_from_day),
-                            ),
-                            originalTextStyle = SusuTheme.typography.title_m,
-                            spanStyle = SusuTheme.typography.title_m.copy(Gray80).toSpanStyle(),
-                        )
-                        AnnotatedText(
-                            originalText = stringResource(R.string.ledger_edit_screen_until_date, 2023, 11, 25),
-                            targetTextList = listOf(
-                                stringResource(R.string.ledger_edit_screen_year),
-                                stringResource(R.string.ledger_edit_screen_month),
-                                stringResource(R.string.ledger_edit_screen_until_day),
-                            ),
-                            originalTextStyle = SusuTheme.typography.title_m,
-                            spanStyle = SusuTheme.typography.title_m.copy(Gray80).toSpanStyle(),
-                        )
-                    }
-                },
-            )
+                            AddConditionButton(onClick = {})
+
+                            SusuTextFieldWrapContentButton(
+                                color = TextFieldButtonColor.Orange,
+                                style = SmallTextFieldButtonStyle.height32,
+                                text = "친척 장례식",
+                                isSaved = true,
+                            )
+                        }
+                    },
+                )
+
+                LedgerEditContainer(
+                    name = stringResource(com.susu.core.ui.R.string.word_date),
+                    verticalAlignment = Alignment.Top,
+                    content = {
+                        Column {
+                            AnnotatedText(
+                                originalText = stringResource(R.string.ledger_edit_screen_from_date, 2023, 11, 25),
+                                targetTextList = listOf(
+                                    stringResource(R.string.ledger_edit_screen_year),
+                                    stringResource(R.string.ledger_edit_screen_month),
+                                    stringResource(R.string.ledger_edit_screen_from_day),
+                                ),
+                                originalTextStyle = SusuTheme.typography.title_m,
+                                spanStyle = SusuTheme.typography.title_m.copy(Gray80).toSpanStyle(),
+                            )
+                            AnnotatedText(
+                                originalText = stringResource(R.string.ledger_edit_screen_until_date, 2023, 11, 25),
+                                targetTextList = listOf(
+                                    stringResource(R.string.ledger_edit_screen_year),
+                                    stringResource(R.string.ledger_edit_screen_month),
+                                    stringResource(R.string.ledger_edit_screen_until_day),
+                                ),
+                                originalTextStyle = SusuTheme.typography.title_m,
+                                spanStyle = SusuTheme.typography.title_m.copy(Gray80).toSpanStyle(),
+                            )
+                        }
+                    },
+                )
+            }
         }
+
+        SusuFilledButton(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .imePadding(),
+            shape = RectangleShape,
+            color = FilledButtonColor.Black,
+            style = MediumButtonStyle.height60,
+            text = stringResource(id = com.susu.core.ui.R.string.word_save),
+        )
     }
 }
 

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeredit/LedgerEditScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeredit/LedgerEditScreen.kt
@@ -1,18 +1,35 @@
 package com.susu.feature.received.ledgeredit
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.susu.core.designsystem.component.appbar.SusuDefaultAppBar
 import com.susu.core.designsystem.component.appbar.icon.BackIcon
+import com.susu.core.designsystem.component.button.AddConditionButton
+import com.susu.core.designsystem.component.button.FilledButtonColor
+import com.susu.core.designsystem.component.button.SmallButtonStyle
+import com.susu.core.designsystem.component.button.SusuFilledButton
+import com.susu.core.designsystem.component.textfieldbutton.SusuTextFieldWrapContentButton
+import com.susu.core.designsystem.component.textfieldbutton.TextFieldButtonColor
+import com.susu.core.designsystem.component.textfieldbutton.style.SmallTextFieldButtonStyle
+import com.susu.core.designsystem.theme.Gray80
 import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.core.ui.util.AnnotatedText
+import com.susu.feature.received.R
+import com.susu.feature.received.ledgeredit.component.LedgerEditContainer
 
 @Composable
 fun LedgerEditRoute(
@@ -21,18 +38,107 @@ fun LedgerEditRoute(
     LedgerEditScreen()
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun LedgerEditScreen() {
-    Box(
+    Column(
         modifier = Modifier
             .background(SusuTheme.colorScheme.background15)
             .fillMaxSize(),
     ) {
-        Column {
-            SusuDefaultAppBar(
-                modifier = Modifier.padding(horizontal = SusuTheme.spacing.spacing_xs),
-                leftIcon = {
-                    BackIcon()
+        SusuDefaultAppBar(
+            leftIcon = {
+                BackIcon()
+            },
+        )
+
+        Spacer(modifier = Modifier.size(23.dp))
+
+        Column(
+            modifier = Modifier
+                .padding(horizontal = SusuTheme.spacing.spacing_m),
+        ) {
+            LedgerEditContainer(
+                name = stringResource(id = com.susu.core.ui.R.string.word_event_name),
+                verticalAlignment = Alignment.CenterVertically,
+                content = {
+                    Text(
+                        text = "고모부 장례식",
+                        style = SusuTheme.typography.title_m,
+                    )
+                },
+            )
+
+            LedgerEditContainer(
+                name = stringResource(id = com.susu.core.ui.R.string.word_category),
+                verticalAlignment = Alignment.Top,
+                content = {
+                    FlowRow(
+                        verticalArrangement = Arrangement.spacedBy(SusuTheme.spacing.spacing_xxs),
+                        horizontalArrangement = Arrangement.spacedBy(SusuTheme.spacing.spacing_xxs),
+                    ) {
+                        SusuFilledButton(
+                            color = FilledButtonColor.Orange,
+                            style = SmallButtonStyle.height32,
+                            text = "결혼식",
+                        )
+
+                        SusuFilledButton(
+                            color = FilledButtonColor.Orange,
+                            style = SmallButtonStyle.height32,
+                            text = "돌잔치",
+                        )
+
+                        SusuFilledButton(
+                            color = FilledButtonColor.Orange,
+                            style = SmallButtonStyle.height32,
+                            text = "장례식",
+                        )
+
+                        SusuFilledButton(
+                            color = FilledButtonColor.Orange,
+                            style = SmallButtonStyle.height32,
+                            text = "생일 기념일",
+                        )
+
+                        AddConditionButton(onClick = {})
+
+                        SusuTextFieldWrapContentButton(
+                            color = TextFieldButtonColor.Orange,
+                            style = SmallTextFieldButtonStyle.height32,
+                            text = "친척 장례식",
+                            isSaved = true,
+                        )
+                    }
+                },
+            )
+
+            LedgerEditContainer(
+                name = stringResource(com.susu.core.ui.R.string.word_date),
+                verticalAlignment = Alignment.Top,
+                content = {
+                    Column {
+                        AnnotatedText(
+                            originalText = stringResource(R.string.ledger_edit_screen_from_date, 2023, 11, 25),
+                            targetTextList = listOf(
+                                stringResource(R.string.ledger_edit_screen_year),
+                                stringResource(R.string.ledger_edit_screen_month),
+                                stringResource(R.string.ledger_edit_screen_from_day),
+                            ),
+                            originalTextStyle = SusuTheme.typography.title_m,
+                            spanStyle = SusuTheme.typography.title_m.copy(Gray80).toSpanStyle(),
+                        )
+                        AnnotatedText(
+                            originalText = stringResource(R.string.ledger_edit_screen_until_date, 2023, 11, 25),
+                            targetTextList = listOf(
+                                stringResource(R.string.ledger_edit_screen_year),
+                                stringResource(R.string.ledger_edit_screen_month),
+                                stringResource(R.string.ledger_edit_screen_until_day),
+                            ),
+                            originalTextStyle = SusuTheme.typography.title_m,
+                            spanStyle = SusuTheme.typography.title_m.copy(Gray80).toSpanStyle(),
+                        )
+                    }
                 },
             )
         }

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeredit/LedgerEditScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeredit/LedgerEditScreen.kt
@@ -33,6 +33,7 @@ import com.susu.feature.received.ledgeredit.component.LedgerEditContainer
 
 @Composable
 fun LedgerEditRoute(
+    @Suppress("unused")
     popBackStack: () -> Unit,
 ) {
     LedgerEditScreen()

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeredit/LedgerEditScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeredit/LedgerEditScreen.kt
@@ -1,0 +1,48 @@
+package com.susu.feature.received.ledgeredit
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.susu.core.designsystem.component.appbar.SusuDefaultAppBar
+import com.susu.core.designsystem.component.appbar.icon.BackIcon
+import com.susu.core.designsystem.theme.SusuTheme
+
+@Composable
+fun LedgerEditRoute(
+    popBackStack: () -> Unit,
+) {
+    LedgerEditScreen()
+}
+
+@Composable
+fun LedgerEditScreen() {
+    Box(
+        modifier = Modifier
+            .background(SusuTheme.colorScheme.background15)
+            .fillMaxSize(),
+    ) {
+        Column {
+            SusuDefaultAppBar(
+                modifier = Modifier.padding(horizontal = SusuTheme.spacing.spacing_xs),
+                leftIcon = {
+                    BackIcon()
+                },
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun ReceivedScreenPreview() {
+    SusuTheme {
+        LedgerEditScreen()
+    }
+}

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeredit/component/LedgerEditContainer.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeredit/component/LedgerEditContainer.kt
@@ -1,0 +1,50 @@
+package com.susu.feature.received.ledgeredit.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.susu.core.designsystem.theme.Gray60
+import com.susu.core.designsystem.theme.SusuTheme
+
+@Composable
+fun LedgerEditContainer(
+    verticalAlignment: Alignment.Vertical,
+    name: String,
+    content: @Composable () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = SusuTheme.spacing.spacing_m),
+        horizontalArrangement = Arrangement.spacedBy(SusuTheme.spacing.spacing_xxs),
+        verticalAlignment = verticalAlignment,
+    ) {
+        Text(
+            modifier = Modifier.width(72.dp),
+            text = name,
+            style = SusuTheme.typography.title_xxs,
+            color = Gray60,
+        )
+
+        content()
+    }
+}
+
+@Preview
+@Composable
+fun LedgerEditContainerPreview() {
+    SusuTheme {
+        LedgerEditContainer(
+            name = "경조사명", verticalAlignment = Alignment.CenterVertically,
+            content = { Text(text = "고모부 장례식", style = SusuTheme.typography.title_m) },
+        )
+    }
+}

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeredit/component/LedgerEditContainer.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeredit/component/LedgerEditContainer.kt
@@ -43,7 +43,8 @@ fun LedgerEditContainer(
 fun LedgerEditContainerPreview() {
     SusuTheme {
         LedgerEditContainer(
-            name = "경조사명", verticalAlignment = Alignment.CenterVertically,
+            name = "경조사명",
+            verticalAlignment = Alignment.CenterVertically,
             content = { Text(text = "고모부 장례식", style = SusuTheme.typography.title_m) },
         )
     }

--- a/feature/received/src/main/java/com/susu/feature/received/navigation/ReceivedNavigation.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/navigation/ReceivedNavigation.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.susu.feature.received.ledgerdetail.LedgerDetailRoute
+import com.susu.feature.received.ledgeredit.LedgerEditRoute
 import com.susu.feature.received.received.ReceivedRoute
 import com.susu.feature.received.search.LedgerSearchRoute
 
@@ -23,11 +24,16 @@ fun NavController.navigateLedgerSearch() {
     navigate(ReceivedRoute.ledgerSearchRoute)
 }
 
+fun NavController.navigateLedgerEdit() {
+    navigate(ReceivedRoute.ledgerEditRoute)
+}
+
 fun NavGraphBuilder.receivedNavGraph(
     padding: PaddingValues,
     navigateLedgerDetail: (Int) -> Unit,
     popBackStack: () -> Unit,
     navigateLedgerSearch: () -> Unit,
+    navigateLedgerEdit: () -> Unit,
 ) {
     composable(route = ReceivedRoute.route) {
         ReceivedRoute(
@@ -46,13 +52,20 @@ fun NavGraphBuilder.receivedNavGraph(
             },
         ),
     ) {
-        LedgerDetailRoute()
+        LedgerDetailRoute(
+            navigateLedgerEdit = navigateLedgerEdit,
+        )
     }
 
     composable(route = ReceivedRoute.ledgerSearchRoute) {
         LedgerSearchRoute(
             popBackStack = popBackStack,
         )
+    }
+    composable(
+        route = ReceivedRoute.ledgerEditRoute,
+    ) {
+        LedgerEditRoute(popBackStack = popBackStack)
     }
 }
 
@@ -61,4 +74,6 @@ object ReceivedRoute {
     const val LEDGER_DETAIL_ARGUMENT_NAME = "ledgerDetailId"
     fun ledgerDetailRoute(id: String = "0") = "ledger-detail/$id"
     const val ledgerSearchRoute = "ledger-search"
+
+    const val ledgerEditRoute = "ledger-edit" // TODO 파라미터 넘기는 방식으로 수정해야함.
 }

--- a/feature/received/src/main/java/com/susu/feature/received/received/ReceivedScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/received/ReceivedScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -112,6 +113,7 @@ fun ReceiveScreen(
                         text = stringResource(com.susu.core.ui.R.string.word_filter),
                         leftIcon = {
                             Icon(
+                                modifier = Modifier.size(16.dp),
                                 painter = painterResource(id = com.susu.core.ui.R.drawable.ic_filter),
                                 contentDescription = stringResource(R.string.content_description_filter_icon),
                             )

--- a/feature/received/src/main/res/values/strings.xml
+++ b/feature/received/src/main/res/values/strings.xml
@@ -9,4 +9,10 @@
     <string name="ledger_search_screen_search_placeholder">찾고 싶은 장부를 검색해보세요</string>
     <string name="ledger_detail_screen_empty_envelope">아직 보낸 봉투가 없어요</string>
     <string name="ledger_detail_screen_add_envelope">받은 봉투 추가하기</string>
+    <string name="ledger_edit_screen_from_date">%d년 %d월 %d일 부터</string>
+    <string name="ledger_edit_screen_until_date">%d년 %d월 %d일 까지</string>
+    <string name="ledger_edit_screen_year">년</string>
+    <string name="ledger_edit_screen_month">월</string>
+    <string name="ledger_edit_screen_from_day">일 부터</string>
+    <string name="ledger_edit_screen_until_day">일 까지</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ compose-material3 = "1.2.0-alpha07"
 activity-compose = "1.7.2"
 androidx-hilt-navigation-compose = "1.1.0"
 compose-stable-marker = "1.0.3"
+compose-accompanist-systemuicontroller = "0.32.0"
 
 androidx-app-compat = "1.6.1"
 androidx-core = "1.12.0"
@@ -119,6 +120,7 @@ lifecycle-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-co
 navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidx-navigation" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "androidx-hilt-navigation-compose" }
 compose-stable-marker = { group = "com.github.skydoves", name = "compose-stable-marker", version.ref = "compose-stable-marker" }
+compose-accompanist-systemuicontroller = { group = "com.google.accompanist", name = "accompanist-systemuicontroller", version.ref = "compose-accompanist-systemuicontroller" }
 
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }


### PR DESCRIPTION
## 💡 Issue
- Resolved: #46 

## 🌱 Key changes
<!--변경사항 적기-->
- 장부 편집 UI 구현
- StatusBar 색상 설정
- AnnotatedText

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->
### 색상 설정
```kotlin
// internal class MainNavigator
val statusBarColor: Color
        @Composable
        get() = when (currentDestination?.route) {
            in listOf(ReceivedRoute.ledgerSearchRoute) -> SusuTheme.colorScheme.background10
            else -> SusuTheme.colorScheme.background15
        }
```

피그마 디자인을 보니 거의 `Gray15`가 백그라운드더라구요~!
`Gray10`이 백그라운드인 Route만 `in listOf()`에 추가해주시면 될거같아요~


### AnnotatedText
요놈 사용하면 보일러플레이트를 많이 줄일 수 있어요~!
사용 방법은 해당 PR의 LedgerEditScreen 보시면 좋을거같아요

## 📸 스크린샷
|스크린샷|
|:--:|
|![image](https://github.com/YAPP-Github/oksusu-susu-android/assets/81678959/b277acc1-d90b-4ad4-bfb4-21dbde4a8b18)|
