### PR TITLE
Feature/mz 111 약관 동의, 회원가입 UI

### DIFF
--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/appbar/SusuProgressAppBar.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/appbar/SusuProgressAppBar.kt
@@ -43,6 +43,7 @@ fun SusuProgressAppBar(
         },
     )
 }
+
 @Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
 @Composable
 fun SusuProgressAppBarPreview() {

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/appbar/SusuProgressAppBar.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/appbar/SusuProgressAppBar.kt
@@ -1,13 +1,9 @@
 package com.susu.core.designsystem.component.appbar
 
-import android.util.Log
-import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
-import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -16,41 +12,22 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.susu.core.designsystem.R
+import com.susu.core.designsystem.component.appbar.icon.BackIcon
 import com.susu.core.designsystem.theme.SusuTheme
-import com.susu.core.ui.extension.susuClickable
 
 @Composable
 fun SusuProgressAppBar(
     modifier: Modifier = Modifier,
-    @DrawableRes leftIcon: Int? = null,
-    leftIconContentDescription: String? = null,
-    leftIconPadding: Dp = SusuTheme.spacing.spacing_xs,
+    leftIcon: @Composable () -> Unit = {},
     currentStep: Int,
     entireStep: Int,
     progressBar: ProgressBarStyle = ProgressBarStyle.SusuProgressBar,
-    onClickBackButton: () -> Unit,
 ) {
     BasicAppBar(
         modifier = modifier,
-        leftIcon = {
-            leftIcon?.let {
-                Icon(
-                    painter = painterResource(id = leftIcon),
-                    contentDescription = leftIconContentDescription,
-                    modifier = Modifier
-                        .susuClickable(
-                            rippleEnabled = true,
-                            onClick = onClickBackButton,
-                        )
-                        .padding(leftIconPadding),
-                )
-            }
-        },
+        leftIcon = leftIcon,
         title = {
             LinearProgressIndicator(
                 progress = { currentStep / entireStep.toFloat() },
@@ -66,25 +43,21 @@ fun SusuProgressAppBar(
         },
     )
 }
-
 @Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
 @Composable
 fun SusuProgressAppBarPreview() {
     val entireStep = 6
     var currentStep by remember { mutableStateOf(1) }
-
     SusuTheme {
         Column(
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
             SusuProgressAppBar(
-                leftIcon = R.drawable.ic_arrow_left,
-                leftIconContentDescription = "뒤로가기",
+                leftIcon = {
+                    BackIcon()
+                },
                 currentStep = currentStep,
                 entireStep = entireStep,
-                onClickBackButton = {
-                    Log.d("확인", "왼쪽 뒤로가기 클릭")
-                },
             )
             Button(
                 onClick = {

--- a/core/model/src/main/java/com/susu/core/model/Term.kt
+++ b/core/model/src/main/java/com/susu/core/model/Term.kt
@@ -1,0 +1,7 @@
+package com.susu.core.model
+
+data class Term(
+    val id: Int,
+    val title: String,
+    val isEssential: Boolean,
+)

--- a/core/model/src/main/java/com/susu/core/model/TermDetail.kt
+++ b/core/model/src/main/java/com/susu/core/model/TermDetail.kt
@@ -1,0 +1,8 @@
+package com.susu.core.model
+
+data class TermDetail(
+    val id: Int,
+    val title: String,
+    val isEssential: Boolean,
+    val description: String
+)

--- a/core/model/src/main/java/com/susu/core/model/TermDetail.kt
+++ b/core/model/src/main/java/com/susu/core/model/TermDetail.kt
@@ -4,5 +4,5 @@ data class TermDetail(
     val id: Int,
     val title: String,
     val isEssential: Boolean,
-    val description: String
+    val description: String,
 )

--- a/core/model/src/main/java/com/susu/core/model/User.kt
+++ b/core/model/src/main/java/com/susu/core/model/User.kt
@@ -3,5 +3,6 @@ package com.susu.core.model
 data class User(
     val name: String,
     val gender: String,
+    val termAgreement: List<Int>,
     val birth: Int,
 )

--- a/core/ui/src/main/java/com/susu/core/ui/Consts.kt
+++ b/core/ui/src/main/java/com/susu/core/ui/Consts.kt
@@ -12,5 +12,5 @@ val alignList
         stringResource(id = R.string.word_align_low_amount),
     )
 
-const val inputLengthLimitation = 10
+const val USER_NAME_MAX_LENGTH = 10
 val nameRegex = Regex("[a-zA-Z가-힣]{0,10}")

--- a/core/ui/src/main/java/com/susu/core/ui/Consts.kt
+++ b/core/ui/src/main/java/com/susu/core/ui/Consts.kt
@@ -11,3 +11,5 @@ val alignList
         stringResource(id = R.string.word_align_high_amount),
         stringResource(id = R.string.word_align_low_amount),
     )
+
+const val inputLengthLimitation = 10

--- a/core/ui/src/main/java/com/susu/core/ui/Consts.kt
+++ b/core/ui/src/main/java/com/susu/core/ui/Consts.kt
@@ -13,3 +13,4 @@ val alignList
     )
 
 const val inputLengthLimitation = 10
+val nameRegex = Regex("[a-zA-Z가-힣]{0,10}")

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -18,4 +18,8 @@
     <string name="word_category">카테고리</string>
     <string name="word_date">날짜</string>
     <string name="content_description_add_button">더하기 버튼</string>
+    <string name="word_male">남성</string>
+    <string name="word_female">여성</string>
+    <string name="word_birth">출생년도</string>
+    <string name="word_next">다음</string>
 </resources>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -22,4 +22,5 @@
     <string name="word_female">여성</string>
     <string name="word_birth">출생년도</string>
     <string name="word_next">다음</string>
+    <string name="word_done">완료</string>
 </resources>

--- a/data/src/main/java/com/susu/data/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/susu/data/data/di/RepositoryModule.kt
@@ -3,10 +3,12 @@ package com.susu.data.data.di
 import com.susu.data.data.repository.LedgerRecentSearchRepositoryImpl
 import com.susu.data.data.repository.LoginRepositoryImpl
 import com.susu.data.data.repository.SignUpRepositoryImpl
+import com.susu.data.data.repository.TermRepositoryImpl
 import com.susu.data.data.repository.TokenRepositoryImpl
 import com.susu.domain.repository.LedgerRecentSearchRepository
 import com.susu.domain.repository.LoginRepository
 import com.susu.domain.repository.SignUpRepository
+import com.susu.domain.repository.TermRepository
 import com.susu.domain.repository.TokenRepository
 import dagger.Binds
 import dagger.Module
@@ -36,4 +38,9 @@ abstract class RepositoryModule {
     abstract fun bindLedgerRecentSearchRepository(
         ledgerRecentSearchRepositoryImpl: LedgerRecentSearchRepositoryImpl,
     ): LedgerRecentSearchRepository
+
+    @Binds
+    abstract fun bindTermRepository(
+        termRepositoryImpl: TermRepositoryImpl,
+    ): TermRepository
 }

--- a/data/src/main/java/com/susu/data/data/repository/TermRepositoryImpl.kt
+++ b/data/src/main/java/com/susu/data/data/repository/TermRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package com.susu.data.data.repository
+
+import com.susu.core.model.Term
+import com.susu.core.model.TermDetail
+import com.susu.data.remote.api.TermService
+import com.susu.data.remote.model.response.toModel
+import com.susu.domain.repository.TermRepository
+import javax.inject.Inject
+
+class TermRepositoryImpl @Inject constructor(
+    private val termService: TermService,
+) : TermRepository {
+    override suspend fun getTerms(): List<Term> = termService.getTerms().getOrThrow().map { it.toModel() }
+
+    override suspend fun getTermDetail(id: Int): TermDetail = termService.getTermDetail(id).getOrThrow().toModel()
+}

--- a/data/src/main/java/com/susu/data/remote/api/TermService.kt
+++ b/data/src/main/java/com/susu/data/remote/api/TermService.kt
@@ -1,0 +1,15 @@
+package com.susu.data.remote.api
+
+import com.susu.data.remote.model.response.TermDetailResponse
+import com.susu.data.remote.model.response.TermResponse
+import com.susu.data.remote.retrofit.ApiResult
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface TermService {
+    @GET("terms")
+    suspend fun getTerms(): ApiResult<List<TermResponse>>
+
+    @GET("terms/{id}")
+    suspend fun getTermDetail(@Path("id") id: Int): ApiResult<TermDetailResponse>
+}

--- a/data/src/main/java/com/susu/data/remote/di/ApiServiceModule.kt
+++ b/data/src/main/java/com/susu/data/remote/di/ApiServiceModule.kt
@@ -1,6 +1,7 @@
 package com.susu.data.remote.di
 
 import com.susu.data.remote.api.SignUpService
+import com.susu.data.remote.api.TermService
 import com.susu.data.remote.api.TokenService
 import com.susu.data.remote.api.UserService
 import dagger.Module
@@ -8,6 +9,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
+import retrofit2.create
 import javax.inject.Singleton
 
 @Module
@@ -30,5 +32,11 @@ object ApiServiceModule {
     @Provides
     fun provideTokenService(@AuthRetrofit retrofit: Retrofit): TokenService {
         return retrofit.create(TokenService::class.java)
+    }
+
+    @Singleton
+    @Provides
+    fun providesTermService(retrofit: Retrofit): TermService {
+        return retrofit.create(TermService::class.java)
     }
 }

--- a/data/src/main/java/com/susu/data/remote/model/request/UserRequest.kt
+++ b/data/src/main/java/com/susu/data/remote/model/request/UserRequest.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 data class UserRequest(
     val name: String,
     val gender: String,
+    val termAgreement: List<Int>,
     val birth: Int,
 )
 
@@ -14,4 +15,5 @@ fun User.toData() = UserRequest(
     name = name,
     gender = gender,
     birth = birth,
+    termAgreement = termAgreement,
 )

--- a/data/src/main/java/com/susu/data/remote/model/request/UserRequest.kt
+++ b/data/src/main/java/com/susu/data/remote/model/request/UserRequest.kt
@@ -6,14 +6,14 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class UserRequest(
     val name: String,
-    val gender: String,
+    val gender: String?,
     val termAgreement: List<Int>,
-    val birth: Int,
+    val birth: Int?,
 )
 
 fun User.toData() = UserRequest(
     name = name,
-    gender = gender,
-    birth = birth,
+    gender = gender.ifEmpty { null },
+    birth = if (birth < 0) null else birth,
     termAgreement = termAgreement,
 )

--- a/data/src/main/java/com/susu/data/remote/model/response/TermResponse.kt
+++ b/data/src/main/java/com/susu/data/remote/model/response/TermResponse.kt
@@ -1,0 +1,33 @@
+package com.susu.data.remote.model.response
+
+import com.susu.core.model.Term
+import com.susu.core.model.TermDetail
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TermResponse(
+    val id: Int,
+    val title: String,
+    val isEssential: Boolean,
+)
+
+@Serializable
+data class TermDetailResponse(
+    val id: Int,
+    val title: String,
+    val description: String,
+    val isEssential: Boolean,
+)
+
+fun TermResponse.toModel(): Term = Term(
+    id = id,
+    title = title,
+    isEssential = isEssential,
+)
+
+fun TermDetailResponse.toModel(): TermDetail = TermDetail(
+    id = id,
+    title = title,
+    description = description,
+    isEssential = isEssential,
+)

--- a/domain/src/main/java/com/susu/domain/repository/TermRepository.kt
+++ b/domain/src/main/java/com/susu/domain/repository/TermRepository.kt
@@ -1,0 +1,9 @@
+package com.susu.domain.repository
+
+import com.susu.core.model.Term
+import com.susu.core.model.TermDetail
+
+interface TermRepository {
+    suspend fun getTerms(): List<Term>
+    suspend fun getTermDetail(id: Int): TermDetail
+}

--- a/domain/src/main/java/com/susu/domain/usecase/loginsignup/GetTermDetailUseCase.kt
+++ b/domain/src/main/java/com/susu/domain/usecase/loginsignup/GetTermDetailUseCase.kt
@@ -1,0 +1,14 @@
+package com.susu.domain.usecase.loginsignup
+
+import com.susu.core.common.runCatchingIgnoreCancelled
+import com.susu.domain.repository.TermRepository
+import javax.inject.Inject
+
+class GetTermDetailUseCase @Inject constructor(
+    private val termRepository: TermRepository,
+) {
+
+    suspend operator fun invoke(termId: Int) = runCatchingIgnoreCancelled {
+        termRepository.getTermDetail(termId)
+    }
+}

--- a/domain/src/main/java/com/susu/domain/usecase/loginsignup/GetTermsUseCase.kt
+++ b/domain/src/main/java/com/susu/domain/usecase/loginsignup/GetTermsUseCase.kt
@@ -1,0 +1,14 @@
+package com.susu.domain.usecase.loginsignup
+
+import com.susu.core.common.runCatchingIgnoreCancelled
+import com.susu.domain.repository.TermRepository
+import javax.inject.Inject
+
+class GetTermsUseCase @Inject constructor(
+    private val termRepository: TermRepository,
+) {
+
+    suspend operator fun invoke() = runCatchingIgnoreCancelled {
+        termRepository.getTerms()
+    }
+}

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/navigation/LoginSignupNavigation.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/navigation/LoginSignupNavigation.kt
@@ -16,49 +16,26 @@ fun NavController.navigateLoginSignup(navOptions: NavOptions) {
 
 fun NavGraphBuilder.loginSignupNavGraph(
     padding: PaddingValues,
-    navController: NavController,
+    navigateToLogin: () -> Unit,
+    navigateToSignUp: () -> Unit,
     navigateToReceived: () -> Unit,
 ) {
     composable(route = LoginSignupRoute.Parent.Vote.route) {
         VoteRoute(
-            navigateToLogin = {
-                navController.navigate(LoginSignupRoute.Parent.Login.route) {
-                    popUpTo(
-                        route = LoginSignupRoute.Parent.Vote.route,
-                    ) {
-                        inclusive = true
-                    }
-                }
-            },
+            navigateToLogin = navigateToLogin,
         )
     }
     composable(route = LoginSignupRoute.Parent.Login.route) {
         LoginRoute(
             navigateToReceived = navigateToReceived,
-            navigateToSignUp = {
-                navController.navigate(LoginSignupRoute.Parent.SignUp.route) {
-                    popUpTo(
-                        route = LoginSignupRoute.Parent.SignUp.route,
-                    ) {
-                        inclusive = true
-                    }
-                }
-            },
+            navigateToSignUp = navigateToSignUp,
         )
     }
     composable(route = LoginSignupRoute.Parent.SignUp.route) {
         SignUpRoute(
             padding = padding,
             navigateToReceived = navigateToReceived,
-            navigateToLogin = {
-                navController.navigate(LoginSignupRoute.Parent.Login.route) {
-                    popUpTo(
-                        route = LoginSignupRoute.Parent.SignUp.route,
-                    ) {
-                        inclusive = true
-                    }
-                }
-            },
+            navigateToLogin = navigateToLogin,
         )
     }
 }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/navigation/LoginSignupNavigation.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/navigation/LoginSignupNavigation.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import com.susu.core.ui.SnackbarToken
 import com.susu.feature.loginsignup.VoteRoute
 import com.susu.feature.loginsignup.login.LoginRoute
 import com.susu.feature.loginsignup.signup.SignUpRoute
@@ -19,6 +20,7 @@ fun NavGraphBuilder.loginSignupNavGraph(
     navigateToLogin: () -> Unit,
     navigateToSignUp: () -> Unit,
     navigateToReceived: () -> Unit,
+    onShowToast: (SnackbarToken) -> Unit,
 ) {
     composable(route = LoginSignupRoute.Parent.Vote.route) {
         VoteRoute(
@@ -36,6 +38,7 @@ fun NavGraphBuilder.loginSignupNavGraph(
             padding = padding,
             navigateToReceived = navigateToReceived,
             navigateToLogin = navigateToLogin,
+            onShowToast = onShowToast,
         )
     }
 }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/navigation/LoginSignupNavigation.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/navigation/LoginSignupNavigation.kt
@@ -6,7 +6,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.susu.feature.loginsignup.VoteRoute
 import com.susu.feature.loginsignup.login.LoginRoute
-import com.susu.feature.loginsignup.signup.SignUpScreen
+import com.susu.feature.loginsignup.signup.SignUpRoute
 
 @Suppress("unused")
 fun NavController.navigateLoginSignup(navOptions: NavOptions) {
@@ -45,8 +45,17 @@ fun NavGraphBuilder.loginSignupNavGraph(
         )
     }
     composable(route = LoginSignupRoute.Parent.SignUp.route) {
-        SignUpScreen(
+        SignUpRoute(
             navigateToReceived = navigateToReceived,
+            navigateToLogin = {
+                navController.navigate(LoginSignupRoute.Parent.Login.route) {
+                    popUpTo(
+                        route = LoginSignupRoute.Parent.Vote.route,
+                    ) {
+                        inclusive = true
+                    }
+                }
+            },
         )
     }
 }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/navigation/LoginSignupNavigation.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/navigation/LoginSignupNavigation.kt
@@ -53,7 +53,7 @@ fun NavGraphBuilder.loginSignupNavGraph(
             navigateToLogin = {
                 navController.navigate(LoginSignupRoute.Parent.Login.route) {
                     popUpTo(
-                        route = LoginSignupRoute.Parent.Vote.route,
+                        route = LoginSignupRoute.Parent.SignUp.route,
                     ) {
                         inclusive = true
                     }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/navigation/LoginSignupNavigation.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/navigation/LoginSignupNavigation.kt
@@ -1,5 +1,6 @@
 package com.susu.feature.loginsignup.navigation
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -14,6 +15,7 @@ fun NavController.navigateLoginSignup(navOptions: NavOptions) {
 }
 
 fun NavGraphBuilder.loginSignupNavGraph(
+    padding: PaddingValues,
     navController: NavController,
     navigateToReceived: () -> Unit,
 ) {
@@ -46,6 +48,7 @@ fun NavGraphBuilder.loginSignupNavGraph(
     }
     composable(route = LoginSignupRoute.Parent.SignUp.route) {
         SignUpRoute(
+            padding = padding,
             navigateToReceived = navigateToReceived,
             navigateToLogin = {
                 navController.navigate(LoginSignupRoute.Parent.Login.route) {

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
@@ -13,6 +13,7 @@ data class SignUpState(
     val currentStep: SignUpStep = SignUpStep.TERMS,
     val agreedTerms: List<Int> = emptyList(),
     val name: String = "",
+    val isNameValid: Boolean = true,
     val gender: Gender = Gender.NONE,
     val birth: Int = 1930,
 ) : UiState

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
@@ -5,10 +5,10 @@ import com.susu.core.ui.base.SideEffect
 import com.susu.core.ui.base.UiState
 import com.susu.feature.loginsignup.R
 
-sealed class SignUpEffect : SideEffect {
-    data object NavigateToLogin : SignUpEffect()
-    data object NavigateToReceived : SignUpEffect()
-    data class ShowToast(val msg: String) : SignUpEffect()
+sealed interface SignUpEffect : SideEffect {
+    data object NavigateToLogin : SignUpEffect
+    data object NavigateToReceived : SignUpEffect
+    data class ShowToast(val msg: String) : SignUpEffect
 }
 
 data class SignUpState(

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
@@ -15,7 +15,7 @@ data class SignUpState(
     val name: String = "",
     val isNameValid: Boolean = true,
     val gender: Gender = Gender.NONE,
-    val birth: Int = 1930,
+    val birth: Int = -1,
 ) : UiState
 
 enum class SignUpStep(

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
@@ -1,7 +1,9 @@
 package com.susu.feature.loginsignup.signup
 
+import androidx.annotation.StringRes
 import com.susu.core.ui.base.SideEffect
 import com.susu.core.ui.base.UiState
+import com.susu.feature.loginsignup.R
 
 sealed class SignUpEffect : SideEffect {
     data object NavigateToLogin : SignUpEffect()
@@ -19,29 +21,29 @@ data class SignUpState(
 ) : UiState
 
 enum class SignUpStep(
-    val appBarTitle: String,
-    val description: String,
-    val bottomButtonText: String,
+    @StringRes val appBarTitle: Int?,
+    @StringRes val description: Int?,
+    @StringRes val bottomButtonText: Int,
 ) {
     TERMS(
-        appBarTitle = "약관 동의",
-        description = "서비스 약관을 위해\n약관에 동의해주세요",
-        bottomButtonText = "다음",
+        appBarTitle = R.string.signup_term_title,
+        description = R.string.signup_term_description,
+        bottomButtonText = com.susu.core.ui.R.string.word_next,
     ),
     TERM_DETAIL(
-        appBarTitle = "서비스 이용 약관",
-        description = "",
-        bottomButtonText = "동의하기",
+        appBarTitle = R.string.signup_term_detail_title,
+        description = null,
+        bottomButtonText = R.string.signup_term_agree,
     ),
     NAME(
-        appBarTitle = "",
-        description = "반가워요!\n이름을 알려주세요",
-        bottomButtonText = "다음",
+        appBarTitle = null,
+        description = R.string.signup_name_description,
+        bottomButtonText = com.susu.core.ui.R.string.word_next,
     ),
     ADDITIONAL(
-        appBarTitle = "",
-        description = "아래 정보들을 알려주시면\n통계를 알려드릴 수 있어요",
-        bottomButtonText = "다음",
+        appBarTitle = null,
+        description = R.string.signup_additional_description,
+        bottomButtonText = com.susu.core.ui.R.string.word_next,
     ),
 }
 

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
@@ -10,9 +10,8 @@ sealed class SignUpEffect : SideEffect {
 }
 
 data class SignUpState(
-    val isNextStepAvailable: Boolean = true,
     val currentStep: SignUpStep = SignUpStep.TERMS,
-    val terms: List<Int> = emptyList(),
+    val agreedTerms: List<Int> = emptyList(),
     val name: String = "",
     val gender: Gender = Gender.NONE,
     val birth: Int = 1930,
@@ -21,18 +20,27 @@ data class SignUpState(
 enum class SignUpStep(
     val appBarTitle: String,
     val description: String,
+    val bottomButtonText: String,
 ) {
     TERMS(
         appBarTitle = "약관 동의",
         description = "서비스 약관을 위해\n약관에 동의해주세요",
+        bottomButtonText = "다음",
+    ),
+    TERM_DETAIL(
+        appBarTitle = "서비스 이용 약관",
+        description = "",
+        bottomButtonText = "동의하기",
     ),
     NAME(
         appBarTitle = "",
         description = "반가워요!\n이름을 알려주세요",
+        bottomButtonText = "다음",
     ),
     ADDITIONAL(
         appBarTitle = "",
         description = "아래 정보들을 알려주시면\n통계를 알려드릴 수 있어요",
+        bottomButtonText = "다음",
     ),
 }
 

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
@@ -3,15 +3,39 @@ package com.susu.feature.loginsignup.signup
 import com.susu.core.ui.base.SideEffect
 import com.susu.core.ui.base.UiState
 
-sealed interface SignUpContract {
-    sealed class SignUpEffect : SideEffect {
-        data object NavigateToReceived : SignUpEffect()
-        data class ShowToast(val msg: String) : SignUpEffect()
-    }
+sealed class SignUpEffect : SideEffect {
+    data object NavigateToLogin : SignUpEffect()
+    data object NavigateToReceived : SignUpEffect()
+    data class ShowToast(val msg: String) : SignUpEffect()
+}
 
-    data class SignUpState(
-        val name: String = "",
-        val gender: String = "M",
-        val birth: String = "0",
-    ) : UiState
+data class SignUpState(
+    val isNextStepAvailable: Boolean = true,
+    val currentStep: SignUpStep = SignUpStep.TERMS,
+    val terms: List<Int> = emptyList(),
+    val name: String = "",
+    val gender: Gender = Gender.NONE,
+    val birth: Int = 1930,
+) : UiState
+
+enum class SignUpStep(
+    val appBarTitle: String,
+    val description: String,
+) {
+    TERMS(
+        appBarTitle = "약관 동의",
+        description = "서비스 약관을 위해\n약관에 동의해주세요",
+    ),
+    NAME(
+        appBarTitle = "",
+        description = "반가워요!\n이름을 알려주세요",
+    ),
+    ADDITIONAL(
+        appBarTitle = "",
+        description = "아래 정보들을 알려주시면\n통계를 알려드릴 수 있어요",
+    ),
+}
+
+enum class Gender(val content: String) {
+    NONE(""), MALE("M"), FEMALE("F")
 }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
@@ -44,7 +44,7 @@ enum class SignUpStep(
     ADDITIONAL(
         appBarTitle = null,
         description = R.string.signup_additional_description,
-        bottomButtonText = com.susu.core.ui.R.string.word_next,
+        bottomButtonText = com.susu.core.ui.R.string.word_done,
     ),
 }
 

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
@@ -12,6 +12,7 @@ sealed class SignUpEffect : SideEffect {
 }
 
 data class SignUpState(
+    val isLoading: Boolean = false,
     val currentStep: SignUpStep = SignUpStep.TERMS,
     val agreedTerms: List<Int> = emptyList(),
     val name: String = "",

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
@@ -215,7 +216,7 @@ fun SignUpScreen(
         }
         content()
         SusuFilledButton(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().imePadding(),
             shape = RectangleShape,
             color = FilledButtonColor.Black,
             style = MediumButtonStyle.height60,

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -1,5 +1,6 @@
 package com.susu.feature.loginsignup.signup
 
+import android.widget.Toast
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.core.tween
@@ -20,6 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -46,6 +48,7 @@ fun SignUpRoute(
     navigateToReceived: () -> Unit,
     navigateToLogin: () -> Unit,
 ) {
+    val context = LocalContext.current
     val uiState: SignUpState by viewModel.uiState.collectAsStateWithLifecycle()
     val termState: TermState by termViewModel.uiState.collectAsStateWithLifecycle()
 
@@ -56,7 +59,7 @@ fun SignUpRoute(
             when (sideEffect) {
                 SignUpEffect.NavigateToLogin -> navigateToLogin()
                 SignUpEffect.NavigateToReceived -> navigateToReceived()
-                is SignUpEffect.ShowToast -> {}
+                is SignUpEffect.ShowToast -> Toast.makeText(context, sideEffect.msg, Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -32,6 +32,7 @@ import com.susu.core.designsystem.component.bottomsheet.datepicker.SusuYearPicke
 import com.susu.core.designsystem.component.button.FilledButtonColor
 import com.susu.core.designsystem.component.button.MediumButtonStyle
 import com.susu.core.designsystem.component.button.SusuFilledButton
+import com.susu.core.designsystem.component.screen.LoadingScreen
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.feature.loginsignup.signup.content.AdditionalContent
 import com.susu.feature.loginsignup.signup.content.NameContent
@@ -161,6 +162,10 @@ fun SignUpRoute(
                     showDatePicker = false
                 },
             )
+        }
+
+        if (uiState.isLoading || termState.isLoading) {
+            LoadingScreen(modifier = Modifier.fillMaxSize())
         }
     }
 }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -115,6 +116,7 @@ fun SignUpScreen(
         content()
         SusuFilledButton(
             modifier = Modifier.fillMaxWidth(),
+            shape = RectangleShape,
             color = FilledButtonColor.Black,
             style = MediumButtonStyle.height60,
             text = "다음",

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -26,6 +26,7 @@ import com.susu.core.designsystem.component.button.FilledButtonColor
 import com.susu.core.designsystem.component.button.MediumButtonStyle
 import com.susu.core.designsystem.component.button.SusuFilledButton
 import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.feature.loginsignup.signup.content.NameContent
 import com.susu.feature.loginsignup.signup.content.TermsContent
 
 @Composable
@@ -51,9 +52,9 @@ fun SignUpRoute(
     SignUpScreen(
         uiState = uiState,
         isNextStepActive = when (uiState.currentStep) {
-            SignUpStep.TERMS -> uiState.agreedTerms.containsAll(listOf(1, 2))
+            SignUpStep.TERMS -> uiState.agreedTerms.containsAll(termState.terms.map { it.id })
             SignUpStep.TERM_DETAIL -> true
-            SignUpStep.NAME -> true
+            SignUpStep.NAME -> uiState.isNameValid && uiState.name.isNotEmpty()
             SignUpStep.ADDITIONAL -> true
         },
         onPreviousPressed = viewModel::goPreviousStep,
@@ -106,7 +107,14 @@ fun SignUpRoute(
                 }
 
                 SignUpStep.NAME -> {
-                    Text(text = targetState.description)
+                    NameContent(
+                        modifier = Modifier.fillMaxSize(),
+                        description = targetState.description,
+                        text = uiState.name,
+                        isError = uiState.isNameValid.not(),
+                        onTextChange = viewModel::updateName,
+                        onClickClearIcon = { viewModel.updateName("") },
+                    )
                 }
 
                 SignUpStep.ADDITIONAL -> {
@@ -152,8 +160,8 @@ fun SignUpScreen(
                         onClick = onPreviousPressed,
                     )
                 },
-                currentStep = SignUpStep.entries.indexOf(uiState.currentStep),
-                entireStep = SignUpStep.entries.size - 1,
+                currentStep = SignUpStep.entries.indexOf(uiState.currentStep) - 1,
+                entireStep = SignUpStep.entries.size - 2,
             )
         }
         content()

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -1,6 +1,5 @@
 package com.susu.feature.loginsignup.signup
 
-import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedContentTransitionScope
@@ -24,7 +23,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -39,6 +37,7 @@ import com.susu.core.designsystem.component.button.MediumButtonStyle
 import com.susu.core.designsystem.component.button.SusuFilledButton
 import com.susu.core.designsystem.component.screen.LoadingScreen
 import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.feature.loginsignup.signup.content.AdditionalContent
 import com.susu.feature.loginsignup.signup.content.NameContent
@@ -52,8 +51,8 @@ fun SignUpRoute(
     termViewModel: TermViewModel = hiltViewModel(),
     navigateToReceived: () -> Unit,
     navigateToLogin: () -> Unit,
+    onShowToast: (SnackbarToken) -> Unit = {},
 ) {
-    val context = LocalContext.current
     val uiState: SignUpState by viewModel.uiState.collectAsStateWithLifecycle()
     val termState: TermState by termViewModel.uiState.collectAsStateWithLifecycle()
 
@@ -67,7 +66,7 @@ fun SignUpRoute(
         when (sideEffect) {
             SignUpEffect.NavigateToLogin -> navigateToLogin()
             SignUpEffect.NavigateToReceived -> navigateToReceived()
-            is SignUpEffect.ShowToast -> Toast.makeText(context, sideEffect.msg, Toast.LENGTH_SHORT).show()
+            is SignUpEffect.ShowToast -> onShowToast(SnackbarToken(message = sideEffect.msg))
         }
     }
 

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -8,26 +8,21 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.susu.core.designsystem.R
 import com.susu.core.designsystem.component.appbar.SusuDefaultAppBar
 import com.susu.core.designsystem.component.appbar.SusuProgressAppBar
+import com.susu.core.designsystem.component.appbar.icon.BackIcon
 import com.susu.core.designsystem.component.button.FilledButtonColor
 import com.susu.core.designsystem.component.button.MediumButtonStyle
 import com.susu.core.designsystem.component.button.SusuFilledButton
 import com.susu.core.designsystem.theme.SusuTheme
-import com.susu.core.ui.extension.susuClickable
 
 @Composable
 fun SignUpRoute(
@@ -99,23 +94,22 @@ fun SignUpScreen(
         if (uiState.currentStep == SignUpStep.TERMS) {
             SusuDefaultAppBar(
                 leftIcon = {
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_arrow_left),
-                        contentDescription = "뒤로가기",
-                        modifier = Modifier.susuClickable(
-                            rippleEnabled = true,
-                            onClick = onPreviousPressed,
-                        ).padding(10.dp),
+                    BackIcon(
+                        onClick = onPreviousPressed
                     )
                 },
                 title = uiState.currentStep.appBarTitle,
             )
         } else {
             SusuProgressAppBar(
-                leftIcon = R.drawable.ic_arrow_left,
+                leftIcon = {
+                    BackIcon(
+                        onClick = onPreviousPressed
+                    )
+                },
                 currentStep = SignUpStep.entries.indexOf(uiState.currentStep),
                 entireStep = SignUpStep.entries.size - 1,
-                onClickBackButton = onPreviousPressed,
+
             )
         }
         content()
@@ -135,7 +129,9 @@ fun SignUpScreen(
 fun SignUpScreenPreview() {
     SusuTheme {
         SignUpScreen {
-            Text("hello", modifier = Modifier.fillMaxWidth().weight(1f))
+            Text("hello", modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f))
         }
     }
 }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -141,7 +141,7 @@ fun SignUpRoute(
 
                     SignUpStep.TERM_DETAIL -> {
                         Text(
-                            modifier = Modifier.fillMaxSize().padding(16.dp),
+                            modifier = Modifier.fillMaxSize().padding(SusuTheme.spacing.spacing_m),
                             text = termState.currentTerm.description,
                             style = SusuTheme.typography.text_xxxs,
                         )
@@ -156,7 +156,7 @@ fun SignUpRoute(
                 onDismissRequest = {
                     viewModel.updateBirth(it)
                     showDatePicker = false
-                }
+                },
             )
         }
     }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -76,7 +76,7 @@ fun SignUpRoute(
         SignUpScreen(
             uiState = uiState,
             isNextStepActive = when (uiState.currentStep) {
-                SignUpStep.TERMS -> uiState.agreedTerms.containsAll(termState.terms.map { it.id })
+                SignUpStep.TERMS -> uiState.agreedTerms.containsAll(termState.terms.filter { it.isEssential }.map { it.id })
                 SignUpStep.TERM_DETAIL -> true
                 SignUpStep.NAME -> uiState.isNameValid && uiState.name.isNotEmpty()
                 SignUpStep.ADDITIONAL -> true

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalContext
@@ -175,7 +176,7 @@ fun SignUpRoute(
         }
 
         if (uiState.isLoading || termState.isLoading) {
-            LoadingScreen(modifier = Modifier.fillMaxSize())
+            LoadingScreen(modifier = Modifier.align(Alignment.Center))
         }
     }
 }
@@ -220,6 +221,7 @@ fun SignUpScreen(
             style = MediumButtonStyle.height60,
             text = stringResource(id = uiState.currentStep.bottomButtonText),
             isActive = isNextStepActive,
+            isClickable = isNextStepActive,
             onClick = onNextPressed,
         )
     }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -43,6 +44,7 @@ import com.susu.feature.loginsignup.signup.content.TermsContent
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SignUpRoute(
+    padding: PaddingValues,
     viewModel: SignUpViewModel = hiltViewModel(),
     termViewModel: TermViewModel = hiltViewModel(),
     navigateToReceived: () -> Unit,
@@ -64,7 +66,7 @@ fun SignUpRoute(
         }
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.fillMaxSize().padding(padding)) {
         SignUpScreen(
             uiState = uiState,
             isNextStepActive = when (uiState.currentStep) {
@@ -175,6 +177,7 @@ fun SignUpRoute(
 
 @Composable
 fun SignUpScreen(
+    modifier: Modifier = Modifier,
     uiState: SignUpState = SignUpState(),
     isNextStepActive: Boolean = false,
     onPreviousPressed: () -> Unit = {},
@@ -182,7 +185,7 @@ fun SignUpScreen(
     content: @Composable ColumnScope.() -> Unit = {},
 ) {
     Column(
-        modifier = Modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
     ) {
         if (uiState.currentStep == SignUpStep.TERMS || uiState.currentStep == SignUpStep.TERM_DETAIL) {
             SusuDefaultAppBar(

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -97,7 +98,7 @@ fun SignUpRoute(
                     SignUpStep.TERMS -> {
                         TermsContent(
                             modifier = Modifier.fillMaxSize(),
-                            descriptionText = targetState.description,
+                            descriptionText = targetState.description?.let { stringResource(id = it) } ?: "",
                             terms = termState.terms,
                             agreedTerms = uiState.agreedTerms,
                             onDetailClick = {
@@ -120,7 +121,7 @@ fun SignUpRoute(
                     SignUpStep.NAME -> {
                         NameContent(
                             modifier = Modifier.fillMaxSize(),
-                            description = targetState.description,
+                            description = targetState.description?.let { stringResource(id = it) } ?: "",
                             text = uiState.name,
                             isError = uiState.isNameValid.not(),
                             onTextChange = viewModel::updateName,
@@ -131,7 +132,7 @@ fun SignUpRoute(
                     SignUpStep.ADDITIONAL -> {
                         AdditionalContent(
                             modifier = Modifier.fillMaxSize(),
-                            description = targetState.description,
+                            description = targetState.description?.let { stringResource(id = it) } ?: "",
                             selectedGender = uiState.gender,
                             selectedYear = uiState.birth,
                             onGenderSelect = viewModel::updateGender,
@@ -141,7 +142,9 @@ fun SignUpRoute(
 
                     SignUpStep.TERM_DETAIL -> {
                         Text(
-                            modifier = Modifier.fillMaxSize().padding(SusuTheme.spacing.spacing_m),
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(SusuTheme.spacing.spacing_m),
                             text = termState.currentTerm.description,
                             style = SusuTheme.typography.text_xxxs,
                         )
@@ -180,7 +183,7 @@ fun SignUpScreen(
                         onClick = onPreviousPressed,
                     )
                 },
-                title = uiState.currentStep.appBarTitle,
+                title = uiState.currentStep.appBarTitle?.let { stringResource(id = it) } ?: "",
             )
         } else {
             SusuProgressAppBar(
@@ -199,7 +202,7 @@ fun SignUpScreen(
             shape = RectangleShape,
             color = FilledButtonColor.Black,
             style = MediumButtonStyle.height60,
-            text = uiState.currentStep.bottomButtonText,
+            text = stringResource(id = uiState.currentStep.bottomButtonText),
             isActive = isNextStepActive,
             onClick = onNextPressed,
         )

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -40,6 +39,7 @@ import com.susu.core.designsystem.component.button.MediumButtonStyle
 import com.susu.core.designsystem.component.button.SusuFilledButton
 import com.susu.core.designsystem.component.screen.LoadingScreen
 import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.feature.loginsignup.signup.content.AdditionalContent
 import com.susu.feature.loginsignup.signup.content.NameContent
 import com.susu.feature.loginsignup.signup.content.TermsContent
@@ -63,13 +63,11 @@ fun SignUpRoute(
         viewModel.goPreviousStep()
     }
 
-    LaunchedEffect(key1 = viewModel.sideEffect) {
-        viewModel.sideEffect.collect { sideEffect ->
-            when (sideEffect) {
-                SignUpEffect.NavigateToLogin -> navigateToLogin()
-                SignUpEffect.NavigateToReceived -> navigateToReceived()
-                is SignUpEffect.ShowToast -> Toast.makeText(context, sideEffect.msg, Toast.LENGTH_SHORT).show()
-            }
+    viewModel.sideEffect.collectWithLifecycle { sideEffect ->
+        when (sideEffect) {
+            SignUpEffect.NavigateToLogin -> navigateToLogin()
+            SignUpEffect.NavigateToReceived -> navigateToReceived()
+            is SignUpEffect.ShowToast -> Toast.makeText(context, sideEffect.msg, Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -1,6 +1,7 @@
 package com.susu.feature.loginsignup.signup
 
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.core.tween
@@ -55,6 +56,10 @@ fun SignUpRoute(
     val termState: TermState by termViewModel.uiState.collectAsStateWithLifecycle()
 
     var showDatePicker by remember { mutableStateOf(false) }
+
+    BackHandler {
+        viewModel.goPreviousStep()
+    }
 
     LaunchedEffect(key1 = viewModel.sideEffect) {
         viewModel.sideEffect.collect { sideEffect ->

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -92,9 +92,11 @@ fun SignUpRoute(
                 targetState = uiState.currentStep,
                 label = "SignUpContent",
                 transitionSpec = {
-                    val direction = if (targetState.ordinal > initialState.ordinal)
+                    val direction = if (targetState.ordinal > initialState.ordinal) {
                         AnimatedContentTransitionScope.SlideDirection.Left
-                    else AnimatedContentTransitionScope.SlideDirection.Right
+                    } else {
+                        AnimatedContentTransitionScope.SlideDirection.Right
+                    }
                     slideIntoContainer(
                         towards = direction,
                         animationSpec = tween(500),

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
@@ -16,7 +16,7 @@ class SignUpViewModel @Inject constructor(
 
     fun updateName(name: String) {
         val trimmedName = name.trim()
-        val slicedName = if (trimmedName.length > 20) trimmedName.slice(0 until 20) else trimmedName
+        val slicedName = if (trimmedName.length > 10) trimmedName.slice(0 until 10) else trimmedName
 
         intent { copy(name = slicedName, isNameValid = nameRegex.matches(slicedName)) }
     }
@@ -78,6 +78,7 @@ class SignUpViewModel @Inject constructor(
                             name = uiState.value.name,
                             gender = uiState.value.gender.content,
                             birth = uiState.value.birth,
+                            termAgreement = uiState.value.agreedTerms
                         ),
                     ).onSuccess {
                         postSideEffect(SignUpEffect.NavigateToReceived)

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
@@ -3,6 +3,7 @@ package com.susu.feature.loginsignup.signup
 import androidx.lifecycle.viewModelScope
 import com.susu.core.model.User
 import com.susu.core.ui.base.BaseViewModel
+import com.susu.core.ui.inputLengthLimitation
 import com.susu.domain.usecase.loginsignup.SignUpUseCase
 import com.susu.feature.loginsignup.social.KakaoLoginHelper
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,9 +17,9 @@ class SignUpViewModel @Inject constructor(
 
     fun updateName(name: String) {
         val trimmedName = name.trim()
-        val slicedName = if (trimmedName.length > 10) trimmedName.slice(0 until 10) else trimmedName
+        if (trimmedName.length > inputLengthLimitation) return
 
-        intent { copy(name = slicedName, isNameValid = nameRegex.matches(slicedName)) }
+        intent { copy(name = trimmedName, isNameValid = nameRegex.matches(trimmedName)) }
     }
 
     fun updateGender(gender: Gender) {
@@ -78,7 +79,7 @@ class SignUpViewModel @Inject constructor(
                             name = uiState.value.name,
                             gender = uiState.value.gender.content,
                             birth = uiState.value.birth,
-                            termAgreement = uiState.value.agreedTerms
+                            termAgreement = uiState.value.agreedTerms,
                         ),
                     ).onSuccess {
                         postSideEffect(SignUpEffect.NavigateToReceived)

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
@@ -34,9 +34,8 @@ class SignUpViewModel @Inject constructor(
         intent { copy(agreedTerms = agreedTerms - termId) }
     }
 
-    fun agreeAllTerms() {
-        // TODO: 약관 정보 받아오기
-        intent { copy(agreedTerms = listOf(1, 2)) }
+    fun agreeAllTerms(entireTermIds: List<Int>) {
+        intent { copy(agreedTerms = entireTermIds) }
     }
 
     fun disagreeAllTerms() {
@@ -61,8 +60,7 @@ class SignUpViewModel @Inject constructor(
         }
     }
 
-    fun goTermDetail(termId: Int) {
-        // TODO: termId에 맞는 화면 표시
+    fun goTermDetail() {
         intent { copy(currentStep = SignUpStep.TERM_DETAIL) }
     }
 

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
@@ -2,8 +2,8 @@ package com.susu.feature.loginsignup.signup
 
 import androidx.lifecycle.viewModelScope
 import com.susu.core.model.User
-import com.susu.core.ui.base.BaseViewModel
 import com.susu.core.ui.USER_NAME_MAX_LENGTH
+import com.susu.core.ui.base.BaseViewModel
 import com.susu.core.ui.nameRegex
 import com.susu.domain.usecase.loginsignup.SignUpUseCase
 import com.susu.feature.loginsignup.social.KakaoLoginHelper

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.susu.core.model.User
 import com.susu.core.ui.base.BaseViewModel
 import com.susu.core.ui.inputLengthLimitation
+import com.susu.core.ui.nameRegex
 import com.susu.domain.usecase.loginsignup.SignUpUseCase
 import com.susu.feature.loginsignup.social.KakaoLoginHelper
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -92,9 +93,5 @@ class SignUpViewModel @Inject constructor(
                 intent { copy(isLoading = false) }
             }
         }
-    }
-
-    companion object {
-        private val nameRegex = Regex("[a-zA-Z가-힣]{0,10}")
     }
 }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
@@ -26,9 +26,27 @@ class SignUpViewModel @Inject constructor(
         intent { copy(birth = birth) }
     }
 
+    fun agreeTerm(termId: Int) {
+        intent { copy(agreedTerms = agreedTerms + termId) }
+    }
+
+    fun disagreeTerm(termId: Int) {
+        intent { copy(agreedTerms = agreedTerms - termId) }
+    }
+
+    fun agreeAllTerms() {
+        // TODO: 약관 정보 받아오기
+        intent { copy(agreedTerms = listOf(1, 2)) }
+    }
+
+    fun disagreeAllTerms() {
+        intent { copy(agreedTerms = emptyList()) }
+    }
+
     fun goNextStep() {
         when (uiState.value.currentStep) {
             SignUpStep.TERMS -> intent { copy(currentStep = SignUpStep.NAME) }
+            SignUpStep.TERM_DETAIL -> intent { copy(currentStep = SignUpStep.TERMS) }
             SignUpStep.NAME -> intent { copy(currentStep = SignUpStep.ADDITIONAL) }
             SignUpStep.ADDITIONAL -> signUp()
         }
@@ -37,9 +55,15 @@ class SignUpViewModel @Inject constructor(
     fun goPreviousStep() {
         when (uiState.value.currentStep) {
             SignUpStep.TERMS -> postSideEffect(SignUpEffect.NavigateToLogin)
+            SignUpStep.TERM_DETAIL -> intent { copy(currentStep = SignUpStep.TERMS) }
             SignUpStep.NAME -> intent { copy(currentStep = SignUpStep.TERMS) }
             SignUpStep.ADDITIONAL -> intent { copy(currentStep = SignUpStep.NAME) }
         }
+    }
+
+    fun goTermDetail(termId: Int) {
+        // TODO: termId에 맞는 화면 표시
+        intent { copy(currentStep = SignUpStep.TERM_DETAIL) }
     }
 
     private fun signUp() {

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
@@ -3,7 +3,7 @@ package com.susu.feature.loginsignup.signup
 import androidx.lifecycle.viewModelScope
 import com.susu.core.model.User
 import com.susu.core.ui.base.BaseViewModel
-import com.susu.core.ui.inputLengthLimitation
+import com.susu.core.ui.USER_NAME_MAX_LENGTH
 import com.susu.core.ui.nameRegex
 import com.susu.domain.usecase.loginsignup.SignUpUseCase
 import com.susu.feature.loginsignup.social.KakaoLoginHelper
@@ -18,7 +18,7 @@ class SignUpViewModel @Inject constructor(
 
     fun updateName(name: String) {
         val trimmedName = name.trim()
-        if (trimmedName.length > inputLengthLimitation) return
+        if (trimmedName.length > USER_NAME_MAX_LENGTH) return
 
         intent { copy(name = trimmedName, isNameValid = nameRegex.matches(trimmedName)) }
     }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
@@ -70,6 +70,7 @@ class SignUpViewModel @Inject constructor(
     private fun signUp() {
         KakaoLoginHelper.getAccessToken { oauthAccessToken ->
             viewModelScope.launch {
+                intent { copy(isLoading = true) }
                 if (oauthAccessToken != null) {
                     signUpUseCase(
                         oauthAccessToken = oauthAccessToken,
@@ -86,6 +87,7 @@ class SignUpViewModel @Inject constructor(
                 } else {
                     postSideEffect(SignUpEffect.ShowToast("카카오톡 로그인 에러 발생"))
                 }
+                intent { copy(isLoading = false) }
             }
         }
     }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
@@ -15,7 +15,10 @@ class SignUpViewModel @Inject constructor(
 ) : BaseViewModel<SignUpState, SignUpEffect>(SignUpState()) {
 
     fun updateName(name: String) {
-        intent { copy(name = name) }
+        val trimmedName = name.trim()
+        val slicedName = if (trimmedName.length > 20) trimmedName.slice(0 until 20) else trimmedName
+
+        intent { copy(name = slicedName, isNameValid = nameRegex.matches(slicedName)) }
     }
 
     fun updateGender(gender: Gender) {
@@ -85,5 +88,9 @@ class SignUpViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    companion object {
+        private val nameRegex = Regex("[a-zA-Z가-힣]{0,10}")
     }
 }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/TermContract.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/TermContract.kt
@@ -1,0 +1,13 @@
+package com.susu.feature.loginsignup.signup
+
+import com.susu.core.model.Term
+import com.susu.core.model.TermDetail
+import com.susu.core.ui.base.SideEffect
+import com.susu.core.ui.base.UiState
+
+object TermEffect : SideEffect
+
+data class TermState(
+    val terms: List<Term> = emptyList(),
+    val currentTerm: TermDetail = TermDetail(0, "", false, ""),
+): UiState

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/TermContract.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/TermContract.kt
@@ -8,6 +8,7 @@ import com.susu.core.ui.base.UiState
 object TermEffect : SideEffect
 
 data class TermState(
+    val isLoading: Boolean = false,
     val terms: List<Term> = emptyList(),
     val currentTerm: TermDetail = TermDetail(0, "", false, ""),
-): UiState
+) : UiState

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/TermContract.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/TermContract.kt
@@ -5,7 +5,9 @@ import com.susu.core.model.TermDetail
 import com.susu.core.ui.base.SideEffect
 import com.susu.core.ui.base.UiState
 
-object TermEffect : SideEffect
+sealed interface TermEffect : SideEffect {
+    data class ShowToast(val msg: String) : TermEffect
+}
 
 data class TermState(
     val isLoading: Boolean = false,

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/TermViewModel.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/TermViewModel.kt
@@ -16,20 +16,24 @@ class TermViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
+            intent { copy(isLoading = true) }
             getTermsUseCase().onSuccess {
-                intent { copy(terms = it) }
+                intent { copy(terms = it, isLoading = false) }
             }.onFailure {
                 // TODO: 실패
+                intent { copy(isLoading = false) }
             }
         }
     }
 
     fun updateCurrentTerm(termId: Int) {
         viewModelScope.launch {
+            intent { copy(isLoading = true) }
             getTermDetailUseCase(termId).onSuccess {
-                intent { copy(currentTerm = it) }
+                intent { copy(currentTerm = it, isLoading = false) }
             }.onFailure {
                 // TODO: 실패
+                intent { copy(isLoading = false) }
             }
         }
     }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/TermViewModel.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/TermViewModel.kt
@@ -20,7 +20,7 @@ class TermViewModel @Inject constructor(
             getTermsUseCase().onSuccess {
                 intent { copy(terms = it, isLoading = false) }
             }.onFailure {
-                // TODO: 실패
+                postSideEffect(TermEffect.ShowToast(it.message ?: "약관을 불러오지 못했어요"))
                 intent { copy(isLoading = false) }
             }
         }
@@ -32,7 +32,7 @@ class TermViewModel @Inject constructor(
             getTermDetailUseCase(termId).onSuccess {
                 intent { copy(currentTerm = it, isLoading = false) }
             }.onFailure {
-                // TODO: 실패
+                postSideEffect(TermEffect.ShowToast(it.message ?: "약관 내용을 불러오지 못했어요"))
                 intent { copy(isLoading = false) }
             }
         }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/TermViewModel.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/TermViewModel.kt
@@ -1,0 +1,36 @@
+package com.susu.feature.loginsignup.signup
+
+import androidx.lifecycle.viewModelScope
+import com.susu.core.ui.base.BaseViewModel
+import com.susu.domain.usecase.loginsignup.GetTermDetailUseCase
+import com.susu.domain.usecase.loginsignup.GetTermsUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class TermViewModel @Inject constructor(
+    private val getTermsUseCase: GetTermsUseCase,
+    private val getTermDetailUseCase: GetTermDetailUseCase,
+) : BaseViewModel<TermState, TermEffect>(TermState()) {
+
+    init {
+        viewModelScope.launch {
+            getTermsUseCase().onSuccess {
+                intent { copy(terms = it) }
+            }.onFailure {
+                // TODO: 실패
+            }
+        }
+    }
+
+    fun updateCurrentTerm(termId: Int) {
+        viewModelScope.launch {
+            getTermDetailUseCase(termId).onSuccess {
+                intent { copy(currentTerm = it) }
+            }.onFailure {
+                // TODO: 실패
+            }
+        }
+    }
+}

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/TermViewModel.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/TermViewModel.kt
@@ -21,8 +21,8 @@ class TermViewModel @Inject constructor(
                 intent { copy(terms = it, isLoading = false) }
             }.onFailure {
                 postSideEffect(TermEffect.ShowToast(it.message ?: "약관을 불러오지 못했어요"))
-                intent { copy(isLoading = false) }
             }
+            intent { copy(isLoading = false) }
         }
     }
 
@@ -33,8 +33,8 @@ class TermViewModel @Inject constructor(
                 intent { copy(currentTerm = it, isLoading = false) }
             }.onFailure {
                 postSideEffect(TermEffect.ShowToast(it.message ?: "약관 내용을 불러오지 못했어요"))
-                intent { copy(isLoading = false) }
             }
+            intent { copy(isLoading = false) }
         }
     }
 }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/AdditionalContent.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/AdditionalContent.kt
@@ -19,9 +19,7 @@ import com.susu.core.designsystem.component.button.MediumButtonStyle
 import com.susu.core.designsystem.component.button.SusuGhostButton
 import com.susu.core.designsystem.theme.Gray60
 import com.susu.core.designsystem.theme.SusuTheme
-import com.susu.feature.loginsignup.R
 import com.susu.feature.loginsignup.signup.Gender
-import com.susu.feature.loginsignup.signup.SignUpStep
 import java.time.LocalDate
 
 @Composable
@@ -31,7 +29,7 @@ fun AdditionalContent(
     selectedGender: Gender = Gender.NONE,
     selectedYear: Int = -1,
     onGenderSelect: (Gender) -> Unit = {},
-    onYearClick: () -> Unit = {}
+    onYearClick: () -> Unit = {},
 ) {
     Column(
         modifier = modifier.padding(horizontal = 16.dp, vertical = 24.dp),
@@ -67,12 +65,15 @@ fun AdditionalContent(
         Text(text = stringResource(com.susu.core.ui.R.string.word_birth), style = SusuTheme.typography.title_xxxs, color = Gray60)
         SusuGhostButton(
             modifier = Modifier.fillMaxWidth(),
-            text = if (selectedYear < 0) LocalDate.now().year.toString() else selectedYear.toString(),
+            text = stringResource(
+                id = com.susu.core.designsystem.R.string.word_year_format,
+                if (selectedYear < 0) LocalDate.now().year else selectedYear,
+            ),
             color = GhostButtonColor.Black,
             style = MediumButtonStyle.height60,
             isClickable = true,
             isActive = selectedYear > 0,
-            onClick = onYearClick
+            onClick = onYearClick,
         )
     }
 }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/AdditionalContent.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/AdditionalContent.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.susu.core.designsystem.component.button.GhostButtonColor
@@ -18,6 +19,7 @@ import com.susu.core.designsystem.component.button.MediumButtonStyle
 import com.susu.core.designsystem.component.button.SusuGhostButton
 import com.susu.core.designsystem.theme.Gray60
 import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.feature.loginsignup.R
 import com.susu.feature.loginsignup.signup.Gender
 import com.susu.feature.loginsignup.signup.SignUpStep
 import java.time.LocalDate
@@ -44,25 +46,25 @@ fun AdditionalContent(
         ) {
             SusuGhostButton(
                 modifier = Modifier.weight(1f),
-                text = "남성",
+                text = stringResource(com.susu.core.ui.R.string.word_male),
                 color = GhostButtonColor.Black,
                 style = MediumButtonStyle.height60,
                 isClickable = true,
                 isActive = selectedGender == Gender.MALE,
-                onClick = { onGenderSelect(Gender.MALE) }
+                onClick = { onGenderSelect(Gender.MALE) },
             )
             SusuGhostButton(
                 modifier = Modifier.weight(1f),
-                text = "여성",
+                text = stringResource(com.susu.core.ui.R.string.word_female),
                 color = GhostButtonColor.Black,
                 style = MediumButtonStyle.height60,
                 isClickable = true,
                 isActive = selectedGender == Gender.FEMALE,
-                onClick = { onGenderSelect(Gender.FEMALE) }
+                onClick = { onGenderSelect(Gender.FEMALE) },
             )
         }
         Spacer(modifier = Modifier.height(SusuTheme.spacing.spacing_xl))
-        Text(text = "출생년도", style = SusuTheme.typography.title_xxxs, color = Gray60)
+        Text(text = stringResource(com.susu.core.ui.R.string.word_birth), style = SusuTheme.typography.title_xxxs, color = Gray60)
         SusuGhostButton(
             modifier = Modifier.fillMaxWidth(),
             text = if (selectedYear < 0) LocalDate.now().year.toString() else selectedYear.toString(),
@@ -81,7 +83,6 @@ fun AdditionalContentPreview() {
     SusuTheme {
         AdditionalContent(
             modifier = Modifier.fillMaxSize(),
-            description = SignUpStep.ADDITIONAL.description,
             selectedGender = Gender.MALE,
         )
     }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/AdditionalContent.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/AdditionalContent.kt
@@ -1,0 +1,88 @@
+package com.susu.feature.loginsignup.signup.content
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.susu.core.designsystem.component.button.GhostButtonColor
+import com.susu.core.designsystem.component.button.MediumButtonStyle
+import com.susu.core.designsystem.component.button.SusuGhostButton
+import com.susu.core.designsystem.theme.Gray60
+import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.feature.loginsignup.signup.Gender
+import com.susu.feature.loginsignup.signup.SignUpStep
+import java.time.LocalDate
+
+@Composable
+fun AdditionalContent(
+    modifier: Modifier = Modifier,
+    description: String = "",
+    selectedGender: Gender = Gender.NONE,
+    selectedYear: Int = -1,
+    onGenderSelect: (Gender) -> Unit = {},
+    onYearClick: () -> Unit = {}
+) {
+    Column(
+        modifier = modifier.padding(horizontal = 16.dp, vertical = 24.dp),
+    ) {
+        Text(text = description, style = SusuTheme.typography.title_m)
+        Spacer(modifier = Modifier.height(32.dp))
+        Text(text = "성별", style = SusuTheme.typography.title_xxxs, color = Gray60)
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            SusuGhostButton(
+                modifier = Modifier.weight(1f),
+                text = "남성",
+                color = GhostButtonColor.Black,
+                style = MediumButtonStyle.height60,
+                isClickable = true,
+                isActive = selectedGender == Gender.MALE,
+                onClick = { onGenderSelect(Gender.MALE) }
+            )
+            SusuGhostButton(
+                modifier = Modifier.weight(1f),
+                text = "여성",
+                color = GhostButtonColor.Black,
+                style = MediumButtonStyle.height60,
+                isClickable = true,
+                isActive = selectedGender == Gender.FEMALE,
+                onClick = { onGenderSelect(Gender.FEMALE) }
+            )
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(text = "출생년도", style = SusuTheme.typography.title_xxxs, color = Gray60)
+        SusuGhostButton(
+            modifier = Modifier.fillMaxWidth(),
+            text = if (selectedYear < 0) LocalDate.now().year.toString() else selectedYear.toString(),
+            color = GhostButtonColor.Black,
+            style = MediumButtonStyle.height60,
+            isClickable = true,
+            isActive = selectedYear > 0,
+            onClick = onYearClick
+        )
+    }
+}
+
+@Preview(showSystemUi = true)
+@Composable
+fun AdditionalContentPreview() {
+    SusuTheme {
+        AdditionalContent(
+            modifier = Modifier.fillMaxSize(),
+            description = SignUpStep.ADDITIONAL.description,
+            selectedGender = Gender.MALE,
+        )
+    }
+}

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/AdditionalContent.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/AdditionalContent.kt
@@ -35,12 +35,12 @@ fun AdditionalContent(
         modifier = modifier.padding(horizontal = 16.dp, vertical = 24.dp),
     ) {
         Text(text = description, style = SusuTheme.typography.title_m)
-        Spacer(modifier = Modifier.height(32.dp))
+        Spacer(modifier = Modifier.height(SusuTheme.spacing.spacing_xxl))
         Text(text = "성별", style = SusuTheme.typography.title_xxxs, color = Gray60)
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(SusuTheme.spacing.spacing_xxs))
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(SusuTheme.spacing.spacing_xxs),
         ) {
             SusuGhostButton(
                 modifier = Modifier.weight(1f),
@@ -61,7 +61,7 @@ fun AdditionalContent(
                 onClick = { onGenderSelect(Gender.FEMALE) }
             )
         }
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(SusuTheme.spacing.spacing_xl))
         Text(text = "출생년도", style = SusuTheme.typography.title_xxxs, color = Gray60)
         SusuGhostButton(
             modifier = Modifier.fillMaxWidth(),

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/NameContent.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/NameContent.kt
@@ -9,7 +9,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.susu.core.designsystem.component.textfield.SusuUnderlineTextField
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.feature.loginsignup.signup.SignUpStep
@@ -24,10 +23,10 @@ fun NameContent(
     onClickClearIcon: () -> Unit = {},
 ) {
     Column(
-        modifier = modifier.padding(horizontal = 16.dp, vertical = 24.dp),
+        modifier = modifier.padding(horizontal = SusuTheme.spacing.spacing_m, vertical = SusuTheme.spacing.spacing_xl),
     ) {
         Text(text = description, style = SusuTheme.typography.title_m)
-        Spacer(modifier = Modifier.height(32.dp))
+        Spacer(modifier = Modifier.height(SusuTheme.spacing.spacing_xxl))
         SusuUnderlineTextField(
             text = text,
             placeholder = "김수수",

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/NameContent.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/NameContent.kt
@@ -1,0 +1,52 @@
+package com.susu.feature.loginsignup.signup.content
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.susu.core.designsystem.component.textfield.SusuUnderlineTextField
+import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.feature.loginsignup.signup.SignUpStep
+
+@Composable
+fun NameContent(
+    modifier: Modifier = Modifier,
+    description: String = "",
+    text: String = "",
+    isError: Boolean = false,
+    onTextChange: (String) -> Unit = {},
+    onClickClearIcon: () -> Unit = {},
+) {
+    Column(
+        modifier = modifier.padding(horizontal = 16.dp, vertical = 24.dp),
+    ) {
+        Text(text = description, style = SusuTheme.typography.title_m)
+        Spacer(modifier = Modifier.height(32.dp))
+        SusuUnderlineTextField(
+            text = text,
+            placeholder = "김수수",
+            isError = isError,
+            lengthLimit = 10,
+            description = if (isError && text.isNotEmpty()) "한글과 영문 10자 이내로 입력해주세요" else null,
+            onTextChange = onTextChange,
+            onClickClearIcon = onClickClearIcon,
+        )
+    }
+}
+
+@Preview(showSystemUi = true)
+@Composable
+fun NameContentPreview() {
+    SusuTheme {
+        NameContent(
+            modifier = Modifier.fillMaxSize(),
+            description = SignUpStep.NAME.description,
+        )
+    }
+}

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/NameContent.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/NameContent.kt
@@ -8,9 +8,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.susu.core.designsystem.component.textfield.SusuUnderlineTextField
 import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.feature.loginsignup.R
 import com.susu.feature.loginsignup.signup.SignUpStep
 
 @Composable
@@ -29,10 +31,10 @@ fun NameContent(
         Spacer(modifier = Modifier.height(SusuTheme.spacing.spacing_xxl))
         SusuUnderlineTextField(
             text = text,
-            placeholder = "김수수",
+            placeholder = stringResource(R.string.signup_name_sample),
             isError = isError,
             lengthLimit = 10,
-            description = if (isError && text.isNotEmpty()) "한글과 영문 10자 이내로 입력해주세요" else null,
+            description = if (isError && text.isNotEmpty()) stringResource(R.string.signup_name_limitation) else null,
             onTextChange = onTextChange,
             onClickClearIcon = onClickClearIcon,
         )
@@ -45,7 +47,6 @@ fun NameContentPreview() {
     SusuTheme {
         NameContent(
             modifier = Modifier.fillMaxSize(),
-            description = SignUpStep.NAME.description,
         )
     }
 }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/NameContent.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/NameContent.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.susu.core.designsystem.component.textfield.SusuUnderlineTextField
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.feature.loginsignup.R
-import com.susu.feature.loginsignup.signup.SignUpStep
 
 @Composable
 fun NameContent(

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/TermsContent.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/TermsContent.kt
@@ -33,8 +33,8 @@ import com.susu.core.designsystem.theme.Gray30
 import com.susu.core.designsystem.theme.Gray40
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.model.Term
-import com.susu.core.ui.extension.susuClickable
 import com.susu.core.ui.R
+import com.susu.core.ui.extension.susuClickable
 
 @Composable
 fun TermsContent(

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/TermsContent.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/TermsContent.kt
@@ -1,0 +1,176 @@
+package com.susu.feature.loginsignup.signup.content
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.susu.core.designsystem.component.badge.BadgeColor
+import com.susu.core.designsystem.component.badge.BadgeStyle
+import com.susu.core.designsystem.component.badge.SusuBadge
+import com.susu.core.designsystem.theme.Gray100
+import com.susu.core.designsystem.theme.Gray15
+import com.susu.core.designsystem.theme.Gray30
+import com.susu.core.designsystem.theme.Gray40
+import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.core.model.Term
+import com.susu.core.ui.extension.susuClickable
+import com.susu.core.ui.R
+
+@Composable
+fun TermsContent(
+    modifier: Modifier = Modifier,
+    descriptionText: String = "",
+    terms: List<Term> = emptyList(),
+    agreedTerms: List<Int> = emptyList(),
+    onDetailClick: (termId: Int) -> Unit = {},
+    onSelectAll: (agree: Boolean) -> Unit = {},
+    onTermChecked: (agree: Boolean, id: Int) -> Unit = { _, _ -> },
+) {
+    Column(
+        modifier = modifier.padding(16.dp),
+    ) {
+        Text(
+            text = descriptionText,
+            style = SusuTheme.typography.title_m,
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        TermListItem(
+            title = "전체 동의하기",
+            checked = agreedTerms.containsAll(terms.map { it.id }),
+            isEssential = false,
+            canRead = false,
+            onCheckClick = { onSelectAll(it) },
+        )
+        HorizontalDivider(
+            thickness = 1.dp,
+            color = Gray30,
+        )
+        terms.forEach { term ->
+            TermListItem(
+                title = term.title,
+                checked = agreedTerms.contains(term.id),
+                isEssential = term.isEssential,
+                onDetailClick = { onDetailClick(term.id) },
+                onCheckClick = {
+                    onTermChecked(it, term.id)
+                },
+            )
+        }
+    }
+}
+
+@Composable
+fun TermListItem(
+    modifier: Modifier = Modifier,
+    title: String = "",
+    checked: Boolean = false,
+    isEssential: Boolean = true,
+    canRead: Boolean = true,
+    onCheckClick: (Boolean) -> Unit = {},
+    onDetailClick: () -> Unit = {},
+) {
+    Row(
+        modifier = modifier.padding(vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        TermCheckCircle(isChecked = checked, onCheckedChange = onCheckClick)
+        Spacer(modifier = Modifier.width(16.dp))
+        if (isEssential) {
+            SusuBadge(color = BadgeColor.Blue60, text = "필수", padding = BadgeStyle.smallBadge)
+            Spacer(modifier = Modifier.width(8.dp))
+        }
+        Text(
+            modifier = Modifier.weight(1f),
+            text = title,
+            style = SusuTheme.typography.title_xxs,
+        )
+        if (canRead) {
+            Spacer(modifier = Modifier.width(16.dp))
+            Image(
+                modifier = Modifier
+                    .size(20.dp)
+                    .susuClickable(rippleEnabled = false, onClick = onDetailClick),
+                painter = painterResource(id = R.drawable.ic_arrow_right),
+                contentDescription = "약관 보기",
+            )
+        }
+    }
+}
+
+@Composable
+fun TermCheckCircle(
+    modifier: Modifier = Modifier,
+    isChecked: Boolean,
+    onCheckedChange: (Boolean) -> Unit = {},
+) {
+    Box(
+        modifier = modifier
+            .size(20.dp)
+            .drawBehind {
+                if (isChecked) {
+                    drawCircle(
+                        color = Gray100,
+                        radius = 8.dp.toPx(),
+                    )
+                } else {
+                    drawCircle(
+                        color = Gray40,
+                        radius = 8.dp.toPx(),
+                        style = Stroke(width = 1.dp.toPx()),
+                    )
+                }
+            }
+            .susuClickable(
+                rippleEnabled = false,
+                onClick = { onCheckedChange(isChecked.not()) },
+            ),
+    ) {
+        if (isChecked) {
+            Icon(
+                modifier = Modifier.padding(2.dp),
+                imageVector = Icons.Rounded.Check,
+                contentDescription = null,
+                tint = Gray15,
+            )
+        }
+    }
+}
+
+@Preview(showSystemUi = true)
+@Composable
+fun TermsContentPreview() {
+    SusuTheme {
+        TermsContent(
+            modifier = Modifier.fillMaxSize(),
+            descriptionText = "어쩌구저쩌구\n뭐를해주세요",
+            terms = listOf(Term(1, "노예 계약", true), Term(2, "농노 계약", true)),
+        )
+    }
+}
+
+@Preview
+@Composable
+fun TermCheckCirclePreview() {
+    SusuTheme {
+        TermCheckCircle(isChecked = true)
+    }
+}

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/TermsContent.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/TermsContent.kt
@@ -46,13 +46,13 @@ fun TermsContent(
     onTermChecked: (agree: Boolean, id: Int) -> Unit = { _, _ -> },
 ) {
     Column(
-        modifier = modifier.padding(16.dp),
+        modifier = modifier.padding(SusuTheme.spacing.spacing_m),
     ) {
         Text(
             text = descriptionText,
             style = SusuTheme.typography.title_m,
         )
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(SusuTheme.spacing.spacing_xl))
         TermListItem(
             title = "전체 동의하기",
             checked = agreedTerms.containsAll(terms.map { it.id }),
@@ -89,14 +89,14 @@ fun TermListItem(
     onDetailClick: () -> Unit = {},
 ) {
     Row(
-        modifier = modifier.padding(vertical = 16.dp),
+        modifier = modifier.padding(vertical = SusuTheme.spacing.spacing_m),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         TermCheckCircle(isChecked = checked, onCheckedChange = onCheckClick)
-        Spacer(modifier = Modifier.width(16.dp))
+        Spacer(modifier = Modifier.width(SusuTheme.spacing.spacing_m))
         if (isEssential) {
             SusuBadge(color = BadgeColor.Blue60, text = "필수", padding = BadgeStyle.smallBadge)
-            Spacer(modifier = Modifier.width(8.dp))
+            Spacer(modifier = Modifier.width(SusuTheme.spacing.spacing_xxs))
         }
         Text(
             modifier = Modifier.weight(1f),
@@ -104,7 +104,7 @@ fun TermListItem(
             style = SusuTheme.typography.title_xxs,
         )
         if (canRead) {
-            Spacer(modifier = Modifier.width(16.dp))
+            Spacer(modifier = Modifier.width(SusuTheme.spacing.spacing_m))
             Image(
                 modifier = Modifier
                     .size(20.dp)

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/TermsContent.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/TermsContent.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.susu.core.designsystem.component.badge.BadgeColor
@@ -54,7 +55,7 @@ fun TermsContent(
         )
         Spacer(modifier = Modifier.height(SusuTheme.spacing.spacing_xl))
         TermListItem(
-            title = "전체 동의하기",
+            title = stringResource(com.susu.feature.loginsignup.R.string.signup_term_agree_all),
             checked = agreedTerms.containsAll(terms.map { it.id }),
             isEssential = false,
             canRead = false,
@@ -95,7 +96,11 @@ fun TermListItem(
         TermCheckCircle(isChecked = checked, onCheckedChange = onCheckClick)
         Spacer(modifier = Modifier.width(SusuTheme.spacing.spacing_m))
         if (isEssential) {
-            SusuBadge(color = BadgeColor.Blue60, text = "필수", padding = BadgeStyle.smallBadge)
+            SusuBadge(
+                color = BadgeColor.Blue60,
+                text = stringResource(com.susu.feature.loginsignup.R.string.signup_essential),
+                padding = BadgeStyle.smallBadge,
+            )
             Spacer(modifier = Modifier.width(SusuTheme.spacing.spacing_xxs))
         }
         Text(

--- a/feature/loginsignup/src/main/res/values/strings.xml
+++ b/feature/loginsignup/src/main/res/values/strings.xml
@@ -15,4 +15,14 @@
     <string name="signup_vote_question_3">"은 "</string>
     <string name="signup_vote_question_4">얼마가 적당하다</string>
     <string name="signup_vote_question_5">고\n생각하시나요</string>
+    <string name="signup_name_sample">김수수</string>
+    <string name="signup_name_limitation">한글과 영문 10자 이내로 입력해주세요</string>
+    <string name="signup_term_agree_all">전체 동의하기</string>
+    <string name="signup_essential">필수</string>
+    <string name="signup_term_title">약관 동의</string>
+    <string name="signup_term_description">서비스 약관을 위해\n약관에 동의해주세요</string>
+    <string name="signup_term_detail_title">서비스 이용 약관</string>
+    <string name="signup_term_agree">동의하기</string>
+    <string name="signup_name_description">반가워요!\n이름을 알려주세요</string>
+    <string name="signup_additional_description">아래 정보들을 알려주시면\n통계를 알려드릴 수 있어요</string>
 </resources>

--- a/feature/navigator/src/main/java/com/susu/feature/navigator/MainNavigator.kt
+++ b/feature/navigator/src/main/java/com/susu/feature/navigator/MainNavigator.kt
@@ -69,7 +69,11 @@ internal class MainNavigator(
     }
 
     fun navigateLogin() {
-        navController.navigate(LoginSignupRoute.Parent.Login.route)
+        navController.navigate(LoginSignupRoute.Parent.Login.route) {
+            popUpTo(id = navController.graph.id) {
+                inclusive = true
+            }
+        }
     }
 
     fun navigateSignup() {

--- a/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
+++ b/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
@@ -53,8 +53,9 @@ internal fun MainScreen(
                 startDestination = navigator.startDestination,
             ) {
                 loginSignupNavGraph(
-                    navController = navigator.navController,
                     navigateToReceived = navigator::navigateSent,
+                    navigateToLogin = navigator::navigateLogin,
+                    navigateToSignUp = navigator::navigateSignup,
                     padding = innerPadding
                 )
 

--- a/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
+++ b/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
@@ -55,6 +55,7 @@ internal fun MainScreen(
                 loginSignupNavGraph(
                     navController = navigator.navController,
                     navigateToReceived = navigator::navigateSent,
+                    padding = innerPadding
                 )
 
                 sentNavGraph(

--- a/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
+++ b/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
@@ -56,7 +56,8 @@ internal fun MainScreen(
                     navigateToReceived = navigator::navigateSent,
                     navigateToLogin = navigator::navigateLogin,
                     navigateToSignUp = navigator::navigateSignup,
-                    padding = innerPadding
+                    onShowToast = viewModel::onShowToast,
+                    padding = innerPadding,
                 )
 
                 sentNavGraph(


### PR DESCRIPTION
## 💡 Issue
- Resolved: #50 

## 🌱 Key changes
- 약관동의 ~ 회원가입 까지의 UI
- 서버에서 약관 리스트와 약관 상세정보 가져오기

## ✅ To Reviewers
- 약관동의부터 추가정보까지 여러 Step으로 구성된 UI 형태는 [Jetsurvey](https://github.com/android/compose-samples/tree/main/Jetsurvey)을 참고했습니다
    - 받아요, 보내요의 생성 과정에도 활용하면 좋을 것 같네요!
- @jinukeu (아래 실행영상 참고) 이름 입력 단계에서 imePadding을 적용하고 싶었는데, padding을 주도록 수정했는데도 적용이 안되어서... 리뷰하시면서 문제점 발견하시면 얘기해주세요!  
- 화면에 보이는 이용 약관은 서버에서 보내주고 있는 더미 데이터입니다!
- 회원가입과 약관 동의의 data와 state를 분리하고자 `SignUpViewModel`, `TermViewModel` 2개를 `SignUpRoute`에서 섞어서 사용하고 있습니다. 코드 짤 때는 편했는데, 복잡성이 높아지면서 읽으시면서 많이 헷갈릴 것 같아서 걱정되네요

## 📸 스크린샷

https://github.com/YAPP-Github/oksusu-susu-android/assets/69582122/ae68945a-59b0-459f-becd-828ff776f0a1


