### PR TITLE
Feature/mz 178 sent envelopes detail edit

### DIFF
--- a/feature/navigator/src/main/java/com/susu/feature/navigator/MainNavigator.kt
+++ b/feature/navigator/src/main/java/com/susu/feature/navigator/MainNavigator.kt
@@ -24,6 +24,7 @@ import com.susu.feature.sent.navigation.SentRoute
 import com.susu.feature.sent.navigation.navigateSent
 import com.susu.feature.sent.navigation.navigateSentEnvelope
 import com.susu.feature.sent.navigation.navigateSentEnvelopeDetail
+import com.susu.feature.sent.navigation.navigateSentEnvelopeEdit
 import com.susu.feature.statistics.navigation.navigateStatistics
 
 internal class MainNavigator(
@@ -47,6 +48,7 @@ internal class MainNavigator(
                 ReceivedRoute.ledgerFilterRoute,
                 SentRoute.sentEnvelopeRoute,
                 SentRoute.sentEnvelopeDetailRoute,
+                SentRoute.sentEnvelopeEditRoute,
             ),
             -> SusuTheme.colorScheme.background10
 
@@ -85,6 +87,10 @@ internal class MainNavigator(
 
     fun navigateSentEnvelopeDetail() {
         navController.navigateSentEnvelopeDetail()
+    }
+
+    fun navigateSentEnvelopeEdit() {
+        navController.navigateSentEnvelopeEdit()
     }
 
     fun navigateLogin() {

--- a/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
+++ b/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
@@ -65,6 +65,7 @@ internal fun MainScreen(
                     popBackStack = navigator::popBackStackIfNotHome,
                     navigateSentEnvelope = navigator::navigateSentEnvelope,
                     navigateSentEnvelopeDetail = navigator::navigateSentEnvelopeDetail,
+                    navigateSentEnvelopeEdit = navigator::navigateSentEnvelopeEdit,
                 )
 
                 receivedNavGraph(

--- a/feature/sent/src/main/java/com/susu/feature/envelopedetail/SentEnvelopeDetailScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopedetail/SentEnvelopeDetailScreen.kt
@@ -27,6 +27,7 @@ import com.susu.feature.envelopedetail.component.DetailItem
 fun SentEnvelopeDetailRoute(
     viewModel: SentEnvelopeDetailViewModel = hiltViewModel(),
     popBackStack: () -> Unit,
+    navigateSentEnvelopeEdit: () -> Unit,
 ) {
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
@@ -36,6 +37,7 @@ fun SentEnvelopeDetailRoute(
 
     SentEnvelopeDetailScreen(
         onClickBackIcon = viewModel::popBackStack,
+        onClickEdit = navigateSentEnvelopeEdit,
     )
 }
 

--- a/feature/sent/src/main/java/com/susu/feature/envelopedetail/component/DetailItem.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopedetail/component/DetailItem.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.susu.core.designsystem.theme.Gray100
@@ -55,5 +56,17 @@ fun DetailItem(
                 modifier = modifier.weight(1f),
             )
         }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xffffff)
+@Composable
+fun DetailItem() {
+    SusuTheme {
+        DetailItem(
+            categoryText = "경조사",
+            contentText = "결혼식",
+            isEmptyContent = false,
+        )
     }
 }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditContract.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditContract.kt
@@ -1,0 +1,12 @@
+package com.susu.feature.envelopeedit
+
+import com.susu.core.ui.base.SideEffect
+import com.susu.core.ui.base.UiState
+
+data class SentEnvelopeEditState(
+    val isLoading: Boolean = false,
+) : UiState
+
+sealed interface SentEnvelopeEditSideEffect : SideEffect {
+    data object PopBackStack : SentEnvelopeEditSideEffect
+}

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -80,8 +79,7 @@ fun SentEnvelopeEditScreen(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(SusuTheme.colorScheme.background10)
-            .navigationBarsPadding(),
+            .background(SusuTheme.colorScheme.background10),
     ) {
         Column {
             SusuDefaultAppBar(
@@ -94,8 +92,7 @@ fun SentEnvelopeEditScreen(
             Column(
                 modifier = modifier
                     .verticalScroll(rememberScrollState())
-                    .fillMaxWidth()
-                    .weight(1f)
+                    .fillMaxSize()
                     .padding(
                         start = SusuTheme.spacing.spacing_m,
                         end = SusuTheme.spacing.spacing_m,
@@ -291,7 +288,7 @@ fun SentEnvelopeEditScreen(
         if (isSheetOpen) {
             SusuDatePickerBottomSheet(
                 maximumContainerHeight = 346.dp,
-                onDismissRequest = { _, _, _ -> isSheetOpen = false }
+                onDismissRequest = { _, _, _ -> isSheetOpen = false },
             )
         }
     }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
@@ -1,7 +1,6 @@
 package com.susu.feature.envelopeedit
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -37,12 +36,14 @@ import com.susu.core.designsystem.component.button.MediumButtonStyle
 import com.susu.core.designsystem.component.button.SmallButtonStyle
 import com.susu.core.designsystem.component.button.SusuFilledButton
 import com.susu.core.designsystem.component.textfield.SusuBasicTextField
+import com.susu.core.designsystem.component.textfield.SusuPriceTextField
 import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.Gray30
 import com.susu.core.designsystem.theme.Gray40
 import com.susu.core.designsystem.theme.Gray70
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.ui.extension.collectWithLifecycle
+import com.susu.core.ui.extension.susuClickable
 import com.susu.feature.envelopeedit.component.EditDetailItem
 import com.susu.feature.sent.R
 
@@ -102,8 +103,8 @@ fun SentEnvelopeEditScreen(
                         top = SusuTheme.spacing.spacing_xl,
                     ),
             ) {
-                SusuBasicTextField(
-                    text = "${money}원",
+                SusuPriceTextField(
+                    text = money.toString(),
                     onTextChange = { money = it.toInt() },
                     textStyle = SusuTheme.typography.title_xxl,
                     modifier = modifier.fillMaxWidth(),
@@ -204,7 +205,10 @@ fun SentEnvelopeEditScreen(
                         color = Gray100,
                         modifier = modifier
                             .fillMaxWidth()
-                            .clickable { isSheetOpen = true },
+                            .susuClickable(
+                                rippleEnabled = false,
+                                onClick = { isSheetOpen = true },
+                            ),
                     )
                 }
                 EditDetailItem(

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
@@ -1,0 +1,286 @@
+package com.susu.feature.envelopeedit
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.susu.core.designsystem.component.appbar.SusuDefaultAppBar
+import com.susu.core.designsystem.component.appbar.icon.BackIcon
+import com.susu.core.designsystem.component.bottomsheet.datepicker.SusuDatePickerBottomSheet
+import com.susu.core.designsystem.component.button.AddConditionButton
+import com.susu.core.designsystem.component.button.FilledButtonColor
+import com.susu.core.designsystem.component.button.MediumButtonStyle
+import com.susu.core.designsystem.component.button.SmallButtonStyle
+import com.susu.core.designsystem.component.button.SusuFilledButton
+import com.susu.core.designsystem.component.textfield.SusuBasicTextField
+import com.susu.core.designsystem.theme.Gray100
+import com.susu.core.designsystem.theme.Gray30
+import com.susu.core.designsystem.theme.Gray40
+import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.feature.envelopeedit.component.EditDetailItem
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SentEnvelopeEditScreen(
+    modifier: Modifier = Modifier,
+    onClickBackIcon: () -> Unit = {},
+) {
+    // TODO: 수정 필요
+    var money by remember { mutableStateOf(150000) }
+    var name by remember { mutableStateOf("김철수") }
+    var present by remember { mutableStateOf("") }
+    var phone by remember { mutableStateOf("") }
+    var memo by remember { mutableStateOf("") }
+    var isSheetOpen by remember { mutableStateOf(false) }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(SusuTheme.colorScheme.background10)
+            .navigationBarsPadding(),
+    ) {
+        Column {
+            SusuDefaultAppBar(
+                leftIcon = {
+                    BackIcon(
+                        onClick = onClickBackIcon,
+                    )
+                },
+            )
+            Column(
+                modifier = modifier
+                    .verticalScroll(rememberScrollState())
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .padding(
+                        start = SusuTheme.spacing.spacing_m,
+                        end = SusuTheme.spacing.spacing_m,
+                        top = SusuTheme.spacing.spacing_xl,
+                    ),
+            ) {
+                SusuBasicTextField(
+                    text = "${money}원",
+                    onTextChange = { money = it.toInt() },
+                    textStyle = SusuTheme.typography.title_xxl,
+                    modifier = modifier.fillMaxWidth(),
+                )
+                Spacer(modifier = modifier.size(SusuTheme.spacing.spacing_m))
+                EditDetailItem(
+                    categoryText = "경조사",
+                    categoryTextAlign = Alignment.Top,
+                ) {
+                    SusuFilledButton(
+                        color = FilledButtonColor.Orange,
+                        style = SmallButtonStyle.height32,
+                        text = "결혼식",
+                        isActive = true,
+                        onClick = {},
+                    )
+                    SusuFilledButton(
+                        color = FilledButtonColor.Orange,
+                        style = SmallButtonStyle.height32,
+                        text = "돌잔치",
+                        isActive = false,
+                        onClick = {},
+                    )
+                    SusuFilledButton(
+                        color = FilledButtonColor.Orange,
+                        style = SmallButtonStyle.height32,
+                        text = "장례식",
+                        isActive = false,
+                        onClick = {},
+                    )
+                    SusuFilledButton(
+                        color = FilledButtonColor.Orange,
+                        style = SmallButtonStyle.height32,
+                        text = "생일 기념일",
+                        isActive = false,
+                        onClick = {},
+                    )
+                    AddConditionButton(
+                        onClick = {},
+                    )
+                }
+                EditDetailItem(
+                    categoryText = "이름",
+                    categoryTextAlign = Alignment.CenterVertically,
+                ) {
+                    SusuBasicTextField(
+                        text = name,
+                        onTextChange = { name = it },
+                        placeholder = "김철수",
+                        placeholderColor = Gray30,
+                        textStyle = SusuTheme.typography.title_m,
+                        modifier = modifier.fillMaxWidth(),
+                    )
+                }
+                EditDetailItem(
+                    categoryText = "나와의 관계",
+                    categoryTextAlign = Alignment.Top,
+                ) {
+                    SusuFilledButton(
+                        color = FilledButtonColor.Orange,
+                        style = SmallButtonStyle.height32,
+                        text = "친구",
+                        isActive = true,
+                        onClick = {},
+                    )
+                    SusuFilledButton(
+                        color = FilledButtonColor.Orange,
+                        style = SmallButtonStyle.height32,
+                        text = "가족",
+                        isActive = false,
+                        onClick = {},
+                    )
+                    SusuFilledButton(
+                        color = FilledButtonColor.Orange,
+                        style = SmallButtonStyle.height32,
+                        text = "친척",
+                        isActive = false,
+                        onClick = {},
+                    )
+                    SusuFilledButton(
+                        color = FilledButtonColor.Orange,
+                        style = SmallButtonStyle.height32,
+                        text = "동료",
+                        isActive = false,
+                        onClick = {},
+                    )
+                    AddConditionButton(
+                        onClick = {},
+                    )
+                }
+                EditDetailItem(
+                    categoryText = "날짜",
+                    categoryTextAlign = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "2023년 11월 25일",
+                        style = SusuTheme.typography.title_m,
+                        color = Gray100,
+                        modifier = modifier
+                            .fillMaxWidth()
+                            .clickable { isSheetOpen = true },
+                    )
+                }
+                EditDetailItem(
+                    categoryText = "방문 여부",
+                    categoryTextAlign = Alignment.Top,
+                ) {
+                    SusuFilledButton(
+                        color = FilledButtonColor.Orange,
+                        style = SmallButtonStyle.height32,
+                        text = "예",
+                        isActive = true,
+                        onClick = {},
+                        modifier = modifier.weight(1f),
+                    )
+                    SusuFilledButton(
+                        color = FilledButtonColor.Orange,
+                        style = SmallButtonStyle.height32,
+                        text = "아니요",
+                        isActive = false,
+                        onClick = {},
+                        modifier = modifier.weight(1f),
+                    )
+                }
+                EditDetailItem(
+                    categoryText = "선물",
+                    categoryTextColor = if (present.isNotEmpty()) Gray100 else Gray40,
+                    categoryTextAlign = Alignment.CenterVertically,
+                ) {
+                    SusuBasicTextField(
+                        text = present,
+                        onTextChange = { present = it },
+                        placeholder = "한끼 식사",
+                        placeholderColor = Gray30,
+                        textStyle = SusuTheme.typography.title_m,
+                        modifier = modifier.fillMaxWidth(),
+                    )
+                }
+                EditDetailItem(
+                    categoryText = "연락처",
+                    categoryTextColor = if (phone.isNotEmpty()) Gray100 else Gray40,
+                    categoryTextAlign = Alignment.CenterVertically,
+                ) {
+                    SusuBasicTextField(
+                        text = phone,
+                        onTextChange = { phone = it },
+                        placeholder = "01012345678",
+                        placeholderColor = Gray30,
+                        textStyle = SusuTheme.typography.title_m,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = modifier.fillMaxWidth(),
+                    )
+                }
+                EditDetailItem(
+                    categoryText = "메모",
+                    categoryTextColor = if (memo.isNotEmpty()) Gray100 else Gray40,
+                    categoryTextAlign = Alignment.Top,
+                ) {
+                    SusuBasicTextField(
+                        text = memo,
+                        onTextChange = { memo = it },
+                        placeholder = "입력해주세요",
+                        placeholderColor = Gray30,
+                        textStyle = SusuTheme.typography.title_m,
+                        minLines = 2,
+                        maxLines = 2,
+                        modifier = modifier.fillMaxWidth(),
+                    )
+                }
+                Spacer(modifier = modifier.size(400.dp))
+            }
+        }
+        SusuFilledButton(
+            modifier = modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .imePadding(),
+            color = FilledButtonColor.Black,
+            style = MediumButtonStyle.height60,
+            shape = RectangleShape,
+            text = "저장",
+            onClick = {},
+        )
+
+        // DatePickerBottomSheet
+        if (isSheetOpen) {
+            SusuDatePickerBottomSheet(
+                maximumContainerHeight = 346.dp,
+                onDismissRequest = { _, _, _ -> isSheetOpen = false }
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun SentEnvelopeEditScreenPreview() {
+    SusuTheme {
+        SentEnvelopeEditScreen()
+    }
+}

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
@@ -272,7 +272,7 @@ fun SentEnvelopeEditScreen(
                         modifier = modifier.fillMaxWidth(),
                     )
                 }
-                Spacer(modifier = modifier.size(320.dp))
+                Spacer(modifier = modifier.size(240.dp))
             }
 
             SusuFilledButton(

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.susu.core.designsystem.component.appbar.SusuDefaultAppBar
 import com.susu.core.designsystem.component.appbar.icon.BackIcon
 import com.susu.core.designsystem.component.bottomsheet.datepicker.SusuDatePickerBottomSheet
@@ -42,8 +43,25 @@ import com.susu.core.designsystem.theme.Gray30
 import com.susu.core.designsystem.theme.Gray40
 import com.susu.core.designsystem.theme.Gray70
 import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.feature.envelopeedit.component.EditDetailItem
 import com.susu.feature.sent.R
+
+@Composable
+fun SentEnvelopeEditRoute(
+    viewModel: SentEnvelopeEditViewModel = hiltViewModel(),
+    popBackStack: () -> Unit,
+) {
+    viewModel.sideEffect.collectWithLifecycle { sideEffect ->
+        when (sideEffect) {
+            SentEnvelopeEditSideEffect.PopBackStack -> popBackStack()
+        }
+    }
+
+    SentEnvelopeEditScreen(
+        onClickBackIcon = viewModel::popBackStack,
+    )
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
@@ -50,6 +50,7 @@ import com.susu.feature.sent.R
 fun SentEnvelopeEditRoute(
     viewModel: SentEnvelopeEditViewModel = hiltViewModel(),
     popBackStack: () -> Unit,
+    navigateSentEnvelopeDetail: () -> Unit,
 ) {
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
@@ -59,6 +60,7 @@ fun SentEnvelopeEditRoute(
 
     SentEnvelopeEditScreen(
         onClickBackIcon = viewModel::popBackStack,
+        onClickSave = navigateSentEnvelopeDetail,
     )
 }
 
@@ -67,6 +69,7 @@ fun SentEnvelopeEditRoute(
 fun SentEnvelopeEditScreen(
     modifier: Modifier = Modifier,
     onClickBackIcon: () -> Unit = {},
+    onClickSave: () -> Unit = {},
 ) {
     // TODO: 수정 필요
     var money by remember { mutableStateOf(150000) }
@@ -281,7 +284,7 @@ fun SentEnvelopeEditScreen(
             style = MediumButtonStyle.height60,
             shape = RectangleShape,
             text = stringResource(R.string.sent_envelope_edit_save),
-            onClick = {},
+            onClick = onClickSave,
         )
 
         // DatePickerBottomSheet

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
@@ -40,6 +40,7 @@ import com.susu.core.designsystem.component.textfield.SusuBasicTextField
 import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.Gray30
 import com.susu.core.designsystem.theme.Gray40
+import com.susu.core.designsystem.theme.Gray70
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.feature.envelopeedit.component.EditDetailItem
 import com.susu.feature.sent.R
@@ -135,7 +136,7 @@ fun SentEnvelopeEditScreen(
                         onTextChange = { name = it },
                         placeholder = stringResource(R.string.sent_envelope_edit_category_name_placeholder),
                         placeholderColor = Gray30,
-                        textStyle = SusuTheme.typography.title_m,
+                        textStyle = SusuTheme.typography.title_s,
                         modifier = modifier.fillMaxWidth(),
                     )
                 }
@@ -181,7 +182,7 @@ fun SentEnvelopeEditScreen(
                 ) {
                     Text(
                         text = "2023년 11월 25일",
-                        style = SusuTheme.typography.title_m,
+                        style = SusuTheme.typography.title_s,
                         color = Gray100,
                         modifier = modifier
                             .fillMaxWidth()
@@ -211,7 +212,7 @@ fun SentEnvelopeEditScreen(
                 }
                 EditDetailItem(
                     categoryText = stringResource(R.string.sent_envelope_edit_category_present),
-                    categoryTextColor = if (present.isNotEmpty()) Gray100 else Gray40,
+                    categoryTextColor = if (present.isNotEmpty()) Gray70 else Gray40,
                     categoryTextAlign = Alignment.CenterVertically,
                 ) {
                     SusuBasicTextField(
@@ -219,13 +220,13 @@ fun SentEnvelopeEditScreen(
                         onTextChange = { present = it },
                         placeholder = stringResource(R.string.sent_envelope_edit_category_present_placeholder),
                         placeholderColor = Gray30,
-                        textStyle = SusuTheme.typography.title_m,
+                        textStyle = SusuTheme.typography.title_s,
                         modifier = modifier.fillMaxWidth(),
                     )
                 }
                 EditDetailItem(
                     categoryText = stringResource(R.string.sent_envelope_edit_category_phone),
-                    categoryTextColor = if (phone.isNotEmpty()) Gray100 else Gray40,
+                    categoryTextColor = if (phone.isNotEmpty()) Gray70 else Gray40,
                     categoryTextAlign = Alignment.CenterVertically,
                 ) {
                     SusuBasicTextField(
@@ -233,14 +234,14 @@ fun SentEnvelopeEditScreen(
                         onTextChange = { phone = it },
                         placeholder = stringResource(R.string.sent_envelope_edit_category_phone_placeholder),
                         placeholderColor = Gray30,
-                        textStyle = SusuTheme.typography.title_m,
+                        textStyle = SusuTheme.typography.title_s,
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                         modifier = modifier.fillMaxWidth(),
                     )
                 }
                 EditDetailItem(
                     categoryText = stringResource(R.string.sent_envelope_edit_category_memo),
-                    categoryTextColor = if (memo.isNotEmpty()) Gray100 else Gray40,
+                    categoryTextColor = if (memo.isNotEmpty()) Gray70 else Gray40,
                     categoryTextAlign = Alignment.Top,
                 ) {
                     SusuBasicTextField(
@@ -248,12 +249,12 @@ fun SentEnvelopeEditScreen(
                         onTextChange = { memo = it },
                         placeholder = stringResource(R.string.sent_envelope_edit_category_memo_placeholder),
                         placeholderColor = Gray30,
-                        textStyle = SusuTheme.typography.title_m,
+                        textStyle = SusuTheme.typography.title_s,
                         maxLines = 2,
                         modifier = modifier.fillMaxWidth(),
                     )
                 }
-                Spacer(modifier = modifier.size(400.dp))
+                Spacer(modifier = modifier.size(320.dp))
             }
         }
         SusuFilledButton(

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -41,6 +42,7 @@ import com.susu.core.designsystem.theme.Gray30
 import com.susu.core.designsystem.theme.Gray40
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.feature.envelopeedit.component.EditDetailItem
+import com.susu.feature.sent.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -89,34 +91,34 @@ fun SentEnvelopeEditScreen(
                 )
                 Spacer(modifier = modifier.size(SusuTheme.spacing.spacing_m))
                 EditDetailItem(
-                    categoryText = "경조사",
+                    categoryText = stringResource(R.string.sent_envelope_edit_category_event),
                     categoryTextAlign = Alignment.Top,
                 ) {
                     SusuFilledButton(
                         color = FilledButtonColor.Orange,
                         style = SmallButtonStyle.height32,
-                        text = "결혼식",
+                        text = stringResource(R.string.sent_envelope_edit_category_event_wedding),
                         isActive = true,
                         onClick = {},
                     )
                     SusuFilledButton(
                         color = FilledButtonColor.Orange,
                         style = SmallButtonStyle.height32,
-                        text = "돌잔치",
+                        text = stringResource(R.string.sent_envelope_edit_category_event_first_birth),
                         isActive = false,
                         onClick = {},
                     )
                     SusuFilledButton(
                         color = FilledButtonColor.Orange,
                         style = SmallButtonStyle.height32,
-                        text = "장례식",
+                        text = stringResource(R.string.sent_envelope_edit_category_edit_funeral),
                         isActive = false,
                         onClick = {},
                     )
                     SusuFilledButton(
                         color = FilledButtonColor.Orange,
                         style = SmallButtonStyle.height32,
-                        text = "생일 기념일",
+                        text = stringResource(R.string.sent_envelope_edit_category_edit_birthday),
                         isActive = false,
                         onClick = {},
                     )
@@ -125,47 +127,47 @@ fun SentEnvelopeEditScreen(
                     )
                 }
                 EditDetailItem(
-                    categoryText = "이름",
+                    categoryText = stringResource(R.string.sent_envelope_edit_category_name),
                     categoryTextAlign = Alignment.CenterVertically,
                 ) {
                     SusuBasicTextField(
                         text = name,
                         onTextChange = { name = it },
-                        placeholder = "김철수",
+                        placeholder = stringResource(R.string.sent_envelope_edit_category_name_placeholder),
                         placeholderColor = Gray30,
                         textStyle = SusuTheme.typography.title_m,
                         modifier = modifier.fillMaxWidth(),
                     )
                 }
                 EditDetailItem(
-                    categoryText = "나와의 관계",
+                    categoryText = stringResource(R.string.sent_envelope_edit_category_relationship),
                     categoryTextAlign = Alignment.Top,
                 ) {
                     SusuFilledButton(
                         color = FilledButtonColor.Orange,
                         style = SmallButtonStyle.height32,
-                        text = "친구",
+                        text = stringResource(R.string.sent_envelope_edit_category_relationship_friend),
                         isActive = true,
                         onClick = {},
                     )
                     SusuFilledButton(
                         color = FilledButtonColor.Orange,
                         style = SmallButtonStyle.height32,
-                        text = "가족",
+                        text = stringResource(R.string.sent_envelope_edit_category_relationship_family),
                         isActive = false,
                         onClick = {},
                     )
                     SusuFilledButton(
                         color = FilledButtonColor.Orange,
                         style = SmallButtonStyle.height32,
-                        text = "친척",
+                        text = stringResource(R.string.sent_envelope_edit_category_relationship_relatives),
                         isActive = false,
                         onClick = {},
                     )
                     SusuFilledButton(
                         color = FilledButtonColor.Orange,
                         style = SmallButtonStyle.height32,
-                        text = "동료",
+                        text = stringResource(R.string.sent_envelope_edit_category_relationship_colleague),
                         isActive = false,
                         onClick = {},
                     )
@@ -174,7 +176,7 @@ fun SentEnvelopeEditScreen(
                     )
                 }
                 EditDetailItem(
-                    categoryText = "날짜",
+                    categoryText = stringResource(R.string.sent_envelope_edit_category_date),
                     categoryTextAlign = Alignment.CenterVertically,
                 ) {
                     Text(
@@ -187,13 +189,13 @@ fun SentEnvelopeEditScreen(
                     )
                 }
                 EditDetailItem(
-                    categoryText = "방문 여부",
+                    categoryText = stringResource(R.string.sent_envelope_edit_category_visited),
                     categoryTextAlign = Alignment.Top,
                 ) {
                     SusuFilledButton(
                         color = FilledButtonColor.Orange,
                         style = SmallButtonStyle.height32,
-                        text = "예",
+                        text = stringResource(R.string.sent_envelope_edit_category_visited_yes),
                         isActive = true,
                         onClick = {},
                         modifier = modifier.weight(1f),
@@ -201,35 +203,35 @@ fun SentEnvelopeEditScreen(
                     SusuFilledButton(
                         color = FilledButtonColor.Orange,
                         style = SmallButtonStyle.height32,
-                        text = "아니요",
+                        text = stringResource(R.string.sent_envelope_edit_category_visited_no),
                         isActive = false,
                         onClick = {},
                         modifier = modifier.weight(1f),
                     )
                 }
                 EditDetailItem(
-                    categoryText = "선물",
+                    categoryText = stringResource(R.string.sent_envelope_edit_category_present),
                     categoryTextColor = if (present.isNotEmpty()) Gray100 else Gray40,
                     categoryTextAlign = Alignment.CenterVertically,
                 ) {
                     SusuBasicTextField(
                         text = present,
                         onTextChange = { present = it },
-                        placeholder = "한끼 식사",
+                        placeholder = stringResource(R.string.sent_envelope_edit_category_present_placeholder),
                         placeholderColor = Gray30,
                         textStyle = SusuTheme.typography.title_m,
                         modifier = modifier.fillMaxWidth(),
                     )
                 }
                 EditDetailItem(
-                    categoryText = "연락처",
+                    categoryText = stringResource(R.string.sent_envelope_edit_category_phone),
                     categoryTextColor = if (phone.isNotEmpty()) Gray100 else Gray40,
                     categoryTextAlign = Alignment.CenterVertically,
                 ) {
                     SusuBasicTextField(
                         text = phone,
                         onTextChange = { phone = it },
-                        placeholder = "01012345678",
+                        placeholder = stringResource(R.string.sent_envelope_edit_category_phone_placeholder),
                         placeholderColor = Gray30,
                         textStyle = SusuTheme.typography.title_m,
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
@@ -237,17 +239,16 @@ fun SentEnvelopeEditScreen(
                     )
                 }
                 EditDetailItem(
-                    categoryText = "메모",
+                    categoryText = stringResource(R.string.sent_envelope_edit_category_memo),
                     categoryTextColor = if (memo.isNotEmpty()) Gray100 else Gray40,
                     categoryTextAlign = Alignment.Top,
                 ) {
                     SusuBasicTextField(
                         text = memo,
                         onTextChange = { memo = it },
-                        placeholder = "입력해주세요",
+                        placeholder = stringResource(R.string.sent_envelope_edit_category_memo_placeholder),
                         placeholderColor = Gray30,
                         textStyle = SusuTheme.typography.title_m,
-                        minLines = 2,
                         maxLines = 2,
                         modifier = modifier.fillMaxWidth(),
                     )
@@ -263,7 +264,7 @@ fun SentEnvelopeEditScreen(
             color = FilledButtonColor.Black,
             style = MediumButtonStyle.height60,
             shape = RectangleShape,
-            text = "저장",
+            text = stringResource(R.string.sent_envelope_edit_save),
             onClick = {},
         )
 

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
@@ -95,7 +95,7 @@ fun SentEnvelopeEditScreen(
             Column(
                 modifier = modifier
                     .verticalScroll(rememberScrollState())
-                    .fillMaxSize()
+                    .weight(1f)
                     .padding(
                         start = SusuTheme.spacing.spacing_m,
                         end = SusuTheme.spacing.spacing_m,
@@ -274,18 +274,18 @@ fun SentEnvelopeEditScreen(
                 }
                 Spacer(modifier = modifier.size(320.dp))
             }
+
+            SusuFilledButton(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .imePadding(),
+                color = FilledButtonColor.Black,
+                style = MediumButtonStyle.height60,
+                shape = RectangleShape,
+                text = stringResource(R.string.sent_envelope_edit_save),
+                onClick = onClickSave,
+            )
         }
-        SusuFilledButton(
-            modifier = modifier
-                .fillMaxWidth()
-                .align(Alignment.BottomCenter)
-                .imePadding(),
-            color = FilledButtonColor.Black,
-            style = MediumButtonStyle.height60,
-            shape = RectangleShape,
-            text = stringResource(R.string.sent_envelope_edit_save),
-            onClick = onClickSave,
-        )
 
         // DatePickerBottomSheet
         if (isSheetOpen) {

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditViewModel.kt
@@ -1,0 +1,12 @@
+package com.susu.feature.envelopeedit
+
+import com.susu.core.ui.base.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class SentEnvelopeEditViewModel @Inject constructor() : BaseViewModel<SentEnvelopeEditState, SentEnvelopeEditSideEffect>(
+    SentEnvelopeEditState(),
+) {
+    fun popBackStack() = postSideEffect(SentEnvelopeEditSideEffect.PopBackStack)
+}

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/component/EditDetailItem.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/component/EditDetailItem.kt
@@ -1,6 +1,7 @@
 package com.susu.feature.envelopeedit.component
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
@@ -11,14 +12,27 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.susu.core.designsystem.component.button.AddConditionButton
+import com.susu.core.designsystem.component.button.FilledButtonColor
+import com.susu.core.designsystem.component.button.SmallButtonStyle
+import com.susu.core.designsystem.component.button.SusuFilledButton
+import com.susu.core.designsystem.component.textfield.SusuBasicTextField
+import com.susu.core.designsystem.theme.Gray30
 import com.susu.core.designsystem.theme.Gray70
 import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.feature.sent.R
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -52,6 +66,70 @@ fun EditDetailItem(
             verticalArrangement = Arrangement.spacedBy(SusuTheme.spacing.spacing_xxs),
         ) {
             content()
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xffffff)
+@Composable
+fun DetailItem() {
+    var name by remember { mutableStateOf("김철수") }
+
+    SusuTheme {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            // TextField 버전
+            EditDetailItem(
+                categoryText = "이름",
+                categoryTextAlign = Alignment.CenterVertically,
+            ) {
+                SusuBasicTextField(
+                    text = name,
+                    onTextChange = { name = it },
+                    placeholder = stringResource(R.string.sent_envelope_edit_category_name_placeholder),
+                    placeholderColor = Gray30,
+                    textStyle = SusuTheme.typography.title_s,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            // Button 버전
+            EditDetailItem(
+                categoryText = stringResource(R.string.sent_envelope_edit_category_event),
+                categoryTextAlign = Alignment.Top,
+            ) {
+                SusuFilledButton(
+                    color = FilledButtonColor.Orange,
+                    style = SmallButtonStyle.height32,
+                    text = stringResource(R.string.sent_envelope_edit_category_event_wedding),
+                    isActive = true,
+                    onClick = {},
+                )
+                SusuFilledButton(
+                    color = FilledButtonColor.Orange,
+                    style = SmallButtonStyle.height32,
+                    text = stringResource(R.string.sent_envelope_edit_category_event_first_birth),
+                    isActive = false,
+                    onClick = {},
+                )
+                SusuFilledButton(
+                    color = FilledButtonColor.Orange,
+                    style = SmallButtonStyle.height32,
+                    text = stringResource(R.string.sent_envelope_edit_category_edit_funeral),
+                    isActive = false,
+                    onClick = {},
+                )
+                SusuFilledButton(
+                    color = FilledButtonColor.Orange,
+                    style = SmallButtonStyle.height32,
+                    text = stringResource(R.string.sent_envelope_edit_category_edit_birthday),
+                    isActive = false,
+                    onClick = {},
+                )
+                AddConditionButton(
+                    onClick = {},
+                )
+            }
         }
     }
 }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/component/EditDetailItem.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/component/EditDetailItem.kt
@@ -1,0 +1,57 @@
+package com.susu.feature.envelopeedit.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.susu.core.designsystem.theme.Gray70
+import com.susu.core.designsystem.theme.SusuTheme
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun EditDetailItem(
+    modifier: Modifier = Modifier,
+    categoryText: String,
+    categoryStyle: TextStyle = SusuTheme.typography.title_xxs,
+    categoryTextColor: Color = Gray70,
+    categoryWidth: Dp = 72.dp,
+    categoryTextAlign: Alignment.Vertical,
+    content: @Composable () -> Unit,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = SusuTheme.spacing.spacing_m),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = categoryText,
+            style = categoryStyle,
+            color = categoryTextColor,
+            modifier = modifier
+                .width(categoryWidth)
+                .align(categoryTextAlign),
+        )
+        Spacer(modifier = modifier.size(SusuTheme.spacing.spacing_m))
+        FlowRow(
+            modifier = modifier.weight(1f),
+            horizontalArrangement = Arrangement.spacedBy(SusuTheme.spacing.spacing_xxs),
+            verticalArrangement = Arrangement.spacedBy(SusuTheme.spacing.spacing_xxs),
+        ) {
+            content()
+        }
+    }
+}

--- a/feature/sent/src/main/java/com/susu/feature/sent/navigation/SentNavigation.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/navigation/SentNavigation.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.susu.feature.envelope.SentEnvelopeRoute
 import com.susu.feature.envelopedetail.SentEnvelopeDetailRoute
+import com.susu.feature.envelopeedit.SentEnvelopeEditRoute
 import com.susu.feature.sent.SentRoute
 
 fun NavController.navigateSent(navOptions: NavOptions) {
@@ -21,11 +22,16 @@ fun NavController.navigateSentEnvelopeDetail() {
     navigate(SentRoute.sentEnvelopeDetailRoute)
 }
 
+fun NavController.navigateSentEnvelopeEdit() {
+    navigate(SentRoute.sentEnvelopeEditRoute)
+}
+
 fun NavGraphBuilder.sentNavGraph(
     padding: PaddingValues,
     popBackStack: () -> Unit,
     navigateSentEnvelope: () -> Unit,
     navigateSentEnvelopeDetail: () -> Unit,
+    navigateSentEnvelopeEdit: () -> Unit,
 ) {
     composable(route = SentRoute.route) {
         SentRoute(
@@ -44,6 +50,13 @@ fun NavGraphBuilder.sentNavGraph(
     composable(route = SentRoute.sentEnvelopeDetailRoute) {
         SentEnvelopeDetailRoute(
             popBackStack = popBackStack,
+            navigateSentEnvelopeEdit = navigateSentEnvelopeEdit,
+        )
+    }
+
+    composable(route = SentRoute.sentEnvelopeEditRoute) {
+        SentEnvelopeEditRoute(
+            popBackStack = popBackStack,
         )
     }
 }
@@ -52,4 +65,5 @@ object SentRoute {
     const val route = "sent"
     const val sentEnvelopeRoute = "sent-envelope"
     const val sentEnvelopeDetailRoute = "sent-envelope-detail"
+    const val sentEnvelopeEditRoute = "sent-envelope-edit"
 }

--- a/feature/sent/src/main/java/com/susu/feature/sent/navigation/SentNavigation.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/navigation/SentNavigation.kt
@@ -57,6 +57,7 @@ fun NavGraphBuilder.sentNavGraph(
     composable(route = SentRoute.sentEnvelopeEditRoute) {
         SentEnvelopeEditRoute(
             popBackStack = popBackStack,
+            navigateSentEnvelopeDetail = navigateSentEnvelopeDetail,
         )
     }
 }

--- a/feature/sent/src/main/res/values/strings.xml
+++ b/feature/sent/src/main/res/values/strings.xml
@@ -8,4 +8,27 @@
     <string name="sent_screen_envelope_history_show_all">전체 보기</string>
 
     <string name="content_description_envelope_show_history">내역 보기</string>
+    <string name="sent_envelope_edit_category_event">경조사</string>
+    <string name="sent_envelope_edit_category_name">이름</string>
+    <string name="sent_envelope_edit_category_name_placeholder">김철수</string>
+    <string name="sent_envelope_edit_category_relationship">나와의 관계</string>
+    <string name="sent_envelope_edit_category_date">날짜</string>
+    <string name="sent_envelope_edit_category_visited">방문 여부</string>
+    <string name="sent_envelope_edit_category_present">선물</string>
+    <string name="sent_envelope_edit_category_phone">연락처</string>
+    <string name="sent_envelope_edit_category_memo">메모</string>
+    <string name="sent_envelope_edit_category_event_wedding">결혼식</string>
+    <string name="sent_envelope_edit_category_event_first_birth">돌잔치</string>
+    <string name="sent_envelope_edit_category_edit_funeral">장례식</string>
+    <string name="sent_envelope_edit_category_edit_birthday">생일 기념일</string>
+    <string name="sent_envelope_edit_category_relationship_friend">친구</string>
+    <string name="sent_envelope_edit_category_relationship_family">가족</string>
+    <string name="sent_envelope_edit_category_relationship_relatives">친척</string>
+    <string name="sent_envelope_edit_category_relationship_colleague">동료</string>
+    <string name="sent_envelope_edit_category_visited_yes">예</string>
+    <string name="sent_envelope_edit_category_visited_no">아니요</string>
+    <string name="sent_envelope_edit_category_present_placeholder">한끼 식사</string>
+    <string name="sent_envelope_edit_category_phone_placeholder">01012345678</string>
+    <string name="sent_envelope_edit_category_memo_placeholder">입력해주세요</string>
+    <string name="sent_envelope_edit_save">저장</string>
 </resources>


### PR DESCRIPTION
## 💡 Issue
- Resolved: #55 

## 🌱 Key changes
보내요 봉투 상세 편집 UI 작업 했습니다.

## ✅ To Reviewers
- UI 작업 위주로 작업했습니다.
- `imePadding()`을 적용했는데, 키보드에 가려서 메모 부분 TextField를 누르면 화면이 안보이는 이슈가 있습니다.. 
최종 시안 상에서도 어느 정도 메모 하단 부분에 어느 정도 여백이 있긴 한데, 단순히 해당 여백을 dp로 늘리는 건 좋지 않은 방법인 것 같아서..
혹시 이 부분에 대해서 해결 방법을 아시는 분이 계실까욥...ㅠ

## 📸 스크린샷
|<img width="227" alt="image" src="https://github.com/YAPP-Github/oksusu-susu-android/assets/70886911/56983391-1057-4ccc-a509-a349dc5ab8aa">|
|:--:|
|SentEnvelopeEdit|
