### PR TITLE
Feature/datepicker-click SusuDatePicker 클릭으로 선택

### DIFF
--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/bottomsheet/datepicker/InfiniteColumn.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/bottomsheet/datepicker/InfiniteColumn.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.Gray30
 import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.core.ui.extension.susuClickable
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -41,19 +42,29 @@ fun <T> InfiniteColumn(
     textColor: Color = Gray30,
     selectedTextColor: Color = Gray100,
     onItemSelected: (index: Int, item: T) -> Unit = { _, _ -> },
+    onItemClicked: (item: T) -> Unit = { },
 ) {
     val itemHalfHeight = LocalDensity.current.run { itemHeight.toPx() / 2f }
     var lastSelectedIndex by remember { mutableStateOf(0) }
     var itemsState by remember { mutableStateOf(items) }
     val lazyListState = rememberLazyListState(0)
     val flingBehavior: FlingBehavior = rememberSnapFlingBehavior(lazyListState)
+    var clickedIndex: Int? by remember { mutableStateOf(null) }
 
-    LaunchedEffect(items) {
+    LaunchedEffect(key1 = items) {
         var targetIndex = items.indexOf(initialItem)
         targetIndex += ((Int.MAX_VALUE / 2) / items.size) * items.size
         itemsState = items
         lastSelectedIndex = targetIndex
         lazyListState.scrollToItem(targetIndex - 2, scrollOffset = (itemHeight.value * 0.6f).toInt())
+    }
+
+    LaunchedEffect(clickedIndex) {
+        if (clickedIndex != null) {
+            lastSelectedIndex = clickedIndex!!
+            val targetIndex = clickedIndex!! - 2
+            lazyListState.animateScrollToItem(targetIndex, scrollOffset = (itemHeight.value * 0.6f).toInt())
+        }
     }
 
     LazyColumn(
@@ -85,6 +96,13 @@ fun <T> InfiniteColumn(
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
+                        modifier = Modifier.susuClickable(
+                            onClick = {
+                                clickedIndex = i
+                                onItemClicked(item)
+                            },
+                            rippleEnabled = false,
+                        ),
                         text = item.toString(),
                         style = if (lastSelectedIndex == i) {
                             selectedTextStyle

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/bottomsheet/datepicker/SusuDatePickerBottomSheet.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/bottomsheet/datepicker/SusuDatePickerBottomSheet.kt
@@ -78,6 +78,9 @@ fun SusuDatePickerBottomSheet(
                     }
                     onItemSelected(selectedYear, selectedMonth, selectedDay)
                 },
+                onItemClicked = { item ->
+                    selectedYear = item.dropLast(1).toIntOrNull() ?: currentDate.year
+                },
             )
             InfiniteColumn(
                 modifier = Modifier.width(100.dp),
@@ -95,6 +98,9 @@ fun SusuDatePickerBottomSheet(
                     }
                     onItemSelected(selectedYear, selectedMonth, selectedDay)
                 },
+                onItemClicked = { item ->
+                    selectedMonth = item.dropLast(1).toIntOrNull() ?: currentDate.monthValue
+                },
             )
             InfiniteColumn(
                 modifier = Modifier.width(100.dp),
@@ -105,6 +111,9 @@ fun SusuDatePickerBottomSheet(
                 onItemSelected = { _, item ->
                     selectedDay = item.dropLast(1).toIntOrNull() ?: 1
                     onItemSelected(selectedYear, selectedMonth, selectedDay)
+                },
+                onItemClicked = { item ->
+                    selectedMonth = item.dropLast(1).toIntOrNull() ?: 1
                 },
             )
         }
@@ -234,6 +243,9 @@ fun SusuLimitDatePickerBottomSheet(
                     selectedYear = item.dropLast(1).toIntOrNull() ?: criteriaYear
                     onItemSelected(selectedYear, selectedMonth, selectedDay)
                 },
+                onItemClicked = { item ->
+                    selectedYear = item.dropLast(1).toIntOrNull() ?: criteriaYear
+                },
             )
             if (monthRange.count() > 1) {
                 InfiniteColumn(
@@ -245,6 +257,9 @@ fun SusuLimitDatePickerBottomSheet(
                     onItemSelected = { _, item ->
                         selectedMonth = item.dropLast(1).toIntOrNull() ?: criteriaMonth
                         onItemSelected(selectedYear, selectedMonth, selectedDay)
+                    },
+                    onItemClicked = { item ->
+                        selectedMonth = item.dropLast(1).toIntOrNull() ?: criteriaMonth
                     },
                 )
             } else {
@@ -275,6 +290,9 @@ fun SusuLimitDatePickerBottomSheet(
                     onItemSelected = { _, item ->
                         selectedDay = item.dropLast(1).toIntOrNull() ?: 1
                         onItemSelected(selectedYear, selectedMonth, selectedDay)
+                    },
+                    onItemClicked = { item ->
+                        selectedDay = item.dropLast(1).toIntOrNull() ?: 1
                     },
                 )
             } else {
@@ -312,6 +330,7 @@ fun SusuYearPickerBottomSheet(
     cornerRadius: Dp = 24.dp,
     onDismissRequest: (Int) -> Unit = {},
     onItemSelected: (Int) -> Unit = {},
+    onItemClicked: (Int) -> Unit = {},
 ) {
     val currentYear = remember { LocalDate.now().year }
     var selectedYear by remember { mutableIntStateOf(initialYear ?: currentYear) }
@@ -334,6 +353,7 @@ fun SusuYearPickerBottomSheet(
                 selectedYear = item.dropLast(1).toIntOrNull() ?: currentYear
                 onItemSelected(selectedYear)
             },
+            onItemClicked = { onItemClicked(it.dropLast(1).toIntOrNull() ?: currentYear) },
         )
     }
 }
@@ -365,5 +385,14 @@ fun SusuLimitDatePickerBottomSheetPreview() {
             maximumContainerHeight = 346.dp,
             onDismissRequest = { _, _, _ -> },
         )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview
+@Composable
+fun SusuYearPickerBottomSheetPreview() {
+    SusuTheme {
+        SusuYearPickerBottomSheet(maximumContainerHeight = 300.dp)
     }
 }


### PR DESCRIPTION
## 🌱 Key changes
- 영 불편해서 바텀시트의 항목을 클릭하여 선택하는 기능을 추가했습니다.
- 연도, 날짜, 기간 제한 날짜 3가지 컴포넌트에 모두 적용했습니다.

## 📸 스크린샷

https://github.com/YAPP-Github/oksusu-susu-android/assets/69582122/ea2d8ff2-7164-4f77-99f2-47576cee5dcf

