### PR TITLE
Feature/mz 199 마이페이지 - 내정보 편집, 앱 버전

### DIFF
--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/bottomsheet/datepicker/SusuDatePickerBottomSheet.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/bottomsheet/datepicker/SusuDatePickerBottomSheet.kt
@@ -179,6 +179,7 @@ fun SusuLimitDatePickerBottomSheet(
                             initialMonth == criteriaMonth && initialDay > criteriaDay
                         )
                 -> criteriaDay
+
                 else -> initialDay
             },
         )
@@ -334,7 +335,8 @@ fun SusuYearPickerBottomSheet(
 ) {
     val currentYear = remember { LocalDate.now().year }
     var selectedYear by remember { mutableIntStateOf(initialYear ?: currentYear) }
-    val yearList = yearRange.map { stringResource(id = R.string.word_year_format, it) }.toImmutableList()
+    val yearList =
+        (yearRange.map { stringResource(id = R.string.word_year_format, it) } + listOf(stringResource(R.string.word_not_select))).toImmutableList()
     SusuBottomSheet(
         sheetState = sheetState,
         containerHeight = minOf(maximumContainerHeight, itemHeight * numberOfDisplayedItems + 32.dp),
@@ -350,10 +352,10 @@ fun SusuYearPickerBottomSheet(
             itemHeight = itemHeight,
             numberOfDisplayedItems = numberOfDisplayedItems,
             onItemSelected = { _, item ->
-                selectedYear = item.dropLast(1).toIntOrNull() ?: currentYear
+                selectedYear = item.dropLast(1).toIntOrNull() ?: 0
                 onItemSelected(selectedYear)
             },
-            onItemClicked = { onItemClicked(it.dropLast(1).toIntOrNull() ?: currentYear) },
+            onItemClicked = { onItemClicked(it.dropLast(1).toIntOrNull() ?: 0) },
         )
     }
 }

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -11,4 +11,5 @@
     <string name="content_description_logo_image">로고 이미지</string>
     <string name="content_description_notification_icon">알림 아이콘</string>
     <string name="content_description_filter_icon">필터 아이콘</string>
+    <string name="word_not_select">미선택</string>
 </resources>

--- a/core/ui/src/main/java/com/susu/core/ui/Consts.kt
+++ b/core/ui/src/main/java/com/susu/core/ui/Consts.kt
@@ -21,7 +21,6 @@ val nameRegex = Regex("[a-zA-Z가-힣]{0,10}")
 val USER_BIRTH_RANGE = 1930..2030
 
 const val INTENT_ACTION_DOWNLOAD_COMPLETE = "android.intent.action.DOWNLOAD_COMPLETE"
-
 enum class SnsProviders(
     val path: String,
     @StringRes val nameId: Int,
@@ -33,18 +32,6 @@ enum class SnsProviders(
         nameId = R.string.sns_kakao,
         iconId = R.drawable.ic_kakao_login,
         backgroundColor = Color(0xFFFEE500),
-    ),
-    Naver(
-        path = "",
-        nameId = R.string.sns_naver,
-        iconId = R.drawable.ic_kakao_login,
-        backgroundColor = Color.Unspecified,
-    ),
-    Google(
-        path = "",
-        nameId = R.string.sns_google,
-        iconId = R.drawable.ic_kakao_login,
-        backgroundColor = Color.Unspecified,
     ),
 }
 

--- a/core/ui/src/main/java/com/susu/core/ui/Consts.kt
+++ b/core/ui/src/main/java/com/susu/core/ui/Consts.kt
@@ -18,6 +18,8 @@ val alignList
 const val USER_NAME_MAX_LENGTH = 10
 val nameRegex = Regex("[a-zA-Z가-힣]{0,10}")
 
+val USER_BIRTH_RANGE = 1930..2030
+
 const val INTENT_ACTION_DOWNLOAD_COMPLETE = "android.intent.action.DOWNLOAD_COMPLETE"
 
 enum class SnsProviders(

--- a/core/ui/src/main/java/com/susu/core/ui/Consts.kt
+++ b/core/ui/src/main/java/com/susu/core/ui/Consts.kt
@@ -21,6 +21,7 @@ val nameRegex = Regex("[a-zA-Z가-힣]{0,10}")
 val USER_BIRTH_RANGE = 1930..2030
 
 const val INTENT_ACTION_DOWNLOAD_COMPLETE = "android.intent.action.DOWNLOAD_COMPLETE"
+const val PRIVACY_POLICY_URL = "https://sites.google.com/view/team-oksusu/%ED%99%88"
 enum class SnsProviders(
     val path: String,
     @StringRes val nameId: Int,

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="content_description_add_button">더하기 버튼</string>
     <string name="content_description_close_icon">닫기 아이콘</string>
     <string name="word_input_yourself">직접 입력</string>
+    <string name="word_name">이름</string>
     <string name="word_gender">성별</string>
     <string name="word_male">남성</string>
     <string name="word_female">여성</string>

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/MyPagePrivacyPolicyScreen.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/MyPagePrivacyPolicyScreen.kt
@@ -1,0 +1,26 @@
+package com.susu.feature.mypage
+
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import com.susu.core.ui.PRIVACY_POLICY_URL
+
+@Composable
+fun MyPagePrivacyPolicyScreen(
+    modifier: Modifier = Modifier,
+) {
+    AndroidView(
+        modifier = modifier.fillMaxSize(),
+        factory = { context ->
+            return@AndroidView WebView(context).apply {
+                webViewClient = WebViewClient()
+            }
+        },
+        update = {
+            it.loadUrl(PRIVACY_POLICY_URL)
+        },
+    )
+}

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoContract.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoContract.kt
@@ -7,6 +7,7 @@ import com.susu.core.ui.nameRegex
 
 sealed interface MyPageInfoEffect : SideEffect {
     data object PopBackStack : MyPageInfoEffect
+    data object ShowNameNotValidSnackBar : MyPageInfoEffect
     data class ShowSnackBar(val msg: String) : MyPageInfoEffect
     data class HandleException(val throwable: Throwable, val retry: () -> Unit) : MyPageInfoEffect
 }

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoScreen.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoScreen.kt
@@ -37,9 +37,11 @@ import com.susu.core.designsystem.component.button.SusuFilledButton
 import com.susu.core.designsystem.component.textfield.SusuBasicTextField
 import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.Gray40
+import com.susu.core.designsystem.theme.Gray50
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.ui.Gender
 import com.susu.core.ui.SnackbarToken
+import com.susu.core.ui.USER_BIRTH_RANGE
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.core.ui.extension.susuClickable
 import com.susu.feature.mypage.R
@@ -130,7 +132,7 @@ fun MyPageInfoScreen(
                                 .padding(end = SusuTheme.spacing.spacing_m),
                             text = stringResource(id = com.susu.core.ui.R.string.word_enrollment),
                             style = SusuTheme.typography.title_xxs,
-                            color = Gray100,
+                            color = if (uiState.isEditNameValid) Gray100 else Gray50,
                         )
                     } else {
                         Text(
@@ -154,7 +156,7 @@ fun MyPageInfoScreen(
             )
             Spacer(modifier = Modifier.height(SusuTheme.spacing.spacing_m))
             MyPageInfoItem(
-                title = "이름",
+                title = stringResource(id = com.susu.core.ui.R.string.word_name),
             ) {
                 if (uiState.isEditing) {
                     SusuBasicTextField(
@@ -181,12 +183,23 @@ fun MyPageInfoScreen(
                         modifier = Modifier.susuClickable(
                             onClick = onBirthClick,
                         ),
-                        text = uiState.editBirth.toString(),
+                        text = if (uiState.editBirth in USER_BIRTH_RANGE) {
+                            uiState.editBirth.toString()
+                        } else {
+                            stringResource(id = com.susu.core.ui.R.string.word_not_select)
+                        },
                         style = SusuTheme.typography.title_xs,
                         color = if (uiState.birthEdited) Gray100 else Gray40,
                     )
                 } else {
-                    Text(text = uiState.userBirth.toString(), style = SusuTheme.typography.title_xs, color = Gray100)
+                    Text(
+                        text = if (uiState.userBirth in USER_BIRTH_RANGE) {
+                            uiState.userBirth.toString()
+                        } else {
+                            stringResource(id = com.susu.core.ui.R.string.word_not_select)
+                        },
+                        style = SusuTheme.typography.title_xs, color = Gray100,
+                    )
                 }
             }
             MyPageInfoItem(

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoScreen.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -54,11 +55,16 @@ fun MyPageInfoRoute(
     onShowSnackbar: (SnackbarToken) -> Unit,
     handleException: (Throwable, () -> Unit) -> Unit,
 ) {
+    val context = LocalContext.current
+
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             MyPageInfoEffect.PopBackStack -> popBackStack()
             is MyPageInfoEffect.ShowSnackBar -> onShowSnackbar(SnackbarToken(message = sideEffect.msg))
             is MyPageInfoEffect.HandleException -> handleException(sideEffect.throwable, sideEffect.retry)
+            MyPageInfoEffect.ShowNameNotValidSnackBar -> onShowSnackbar(
+                SnackbarToken(message = context.getString(R.string.mypage_my_info_snackbar_invalid_name)),
+            )
         }
     }
 
@@ -124,11 +130,10 @@ fun MyPageInfoScreen(
                     if (uiState.isEditing) {
                         Text(
                             modifier = Modifier
+                                .padding(end = SusuTheme.spacing.spacing_m)
                                 .susuClickable(
-                                    runIf = uiState.isEditNameValid,
                                     onClick = onEditComplete,
-                                )
-                                .padding(end = SusuTheme.spacing.spacing_m),
+                                ),
                             text = stringResource(id = com.susu.core.ui.R.string.word_enrollment),
                             style = SusuTheme.typography.title_xxs,
                             color = if (uiState.isEditNameValid) Gray100 else Gray50,
@@ -136,8 +141,8 @@ fun MyPageInfoScreen(
                     } else {
                         Text(
                             modifier = Modifier
-                                .susuClickable(onClick = onEditStart)
-                                .padding(end = SusuTheme.spacing.spacing_m),
+                                .padding(end = SusuTheme.spacing.spacing_m)
+                                .susuClickable(onClick = onEditStart),
                             text = stringResource(id = com.susu.core.ui.R.string.word_edit),
                             style = SusuTheme.typography.title_xxs,
                             color = Gray100,

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoScreen.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -157,6 +156,7 @@ fun MyPageInfoScreen(
             Spacer(modifier = Modifier.height(SusuTheme.spacing.spacing_m))
             MyPageInfoItem(
                 title = stringResource(id = com.susu.core.ui.R.string.word_name),
+                isWrong = uiState.isEditing && !uiState.isEditNameValid,
             ) {
                 if (uiState.isEditing) {
                     SusuBasicTextField(

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoScreen.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoScreen.kt
@@ -203,7 +203,8 @@ fun MyPageInfoScreen(
                         } else {
                             stringResource(id = com.susu.core.ui.R.string.word_not_select)
                         },
-                        style = SusuTheme.typography.title_xs, color = Gray100,
+                        style = SusuTheme.typography.title_xs,
+                        color = Gray100,
                     )
                 }
             }

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoViewModel.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoViewModel.kt
@@ -50,7 +50,7 @@ class MyPageInfoViewModel @Inject constructor(
         intent {
             copy(
                 isEditing = true,
-                editName = "",
+                editName = uiState.value.userName,
                 editGender = uiState.value.userGender,
                 editBirth = uiState.value.userBirth,
             )

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoViewModel.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoViewModel.kt
@@ -78,6 +78,11 @@ class MyPageInfoViewModel @Inject constructor(
     }
 
     fun completeEdit() {
+        if (!uiState.value.isEditNameValid) {
+            postSideEffect(MyPageInfoEffect.ShowNameNotValidSnackBar)
+            return
+        }
+
         viewModelScope.launch {
             intent { copy(isLoading = true) }
             patchUserUseCase(name = uiState.value.editName, gender = uiState.value.editGender.content, birth = uiState.value.editBirth)

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/info/component/MyPageInfoItem.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/info/component/MyPageInfoItem.kt
@@ -57,7 +57,7 @@ fun WrongDot(
                 drawCircle(
                     color = color,
                     radius = dotRadius.toPx(),
-                    center = Offset(0f, 8.dp.toPx())
+                    center = Offset(0f, 8.dp.toPx()),
                 )
             },
     )

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/info/component/MyPageInfoItem.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/info/component/MyPageInfoItem.kt
@@ -2,19 +2,30 @@ package com.susu.feature.mypage.info.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.susu.core.designsystem.theme.Gray60
+import com.susu.core.designsystem.theme.Red60
 import com.susu.core.designsystem.theme.SusuTheme
 
 @Composable
 fun MyPageInfoItem(
     modifier: Modifier = Modifier,
     title: String = "",
+    isWrong: Boolean = false,
     content: @Composable () -> Unit,
 ) {
     Row(
@@ -22,7 +33,44 @@ fun MyPageInfoItem(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(text = title, style = SusuTheme.typography.title_xxs, color = Gray60)
+        Row {
+            Text(text = title, style = SusuTheme.typography.title_xxs, color = Gray60)
+            if (isWrong) {
+                Spacer(modifier = Modifier.width(SusuTheme.spacing.spacing_xxxxs))
+                WrongDot()
+            }
+        }
+
         content()
+    }
+}
+
+@Composable
+fun WrongDot(
+    modifier: Modifier = Modifier,
+    dotRadius: Dp = 2.dp,
+    color: Color = Red60,
+) {
+    Spacer(
+        modifier = modifier.width(4.dp).wrapContentHeight()
+            .drawBehind {
+                drawCircle(
+                    color = color,
+                    radius = dotRadius.toPx(),
+                    center = Offset(0f, 8.dp.toPx())
+                )
+            },
+    )
+}
+
+@Preview
+@Composable
+fun MyPageInfoItemPreview() {
+    SusuTheme {
+        MyPageInfoItem(
+            title = "이름",
+            isWrong = true,
+        ) {
+        }
     }
 }

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/main/MyPageDefaultScreen.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/main/MyPageDefaultScreen.kt
@@ -53,6 +53,7 @@ fun MyPageDefaultRoute(
     navigateToLogin: () -> Unit,
     navigateToInfo: () -> Unit,
     navigateToSocial: () -> Unit,
+    navigateToPrivacyPolicy: () -> Unit,
     onShowSnackbar: (SnackbarToken) -> Unit,
     onShowDialog: (DialogToken) -> Unit,
     handleException: (Throwable, () -> Unit) -> Unit,
@@ -138,6 +139,7 @@ fun MyPageDefaultRoute(
         onExport = viewModel::showExportDialog,
         navigateToInfo = navigateToInfo,
         navigateToSocial = navigateToSocial,
+        navigateToPrivacyPolicy = navigateToPrivacyPolicy,
     )
 }
 
@@ -150,6 +152,7 @@ fun MyPageDefaultScreen(
     onExport: () -> Unit = {},
     navigateToInfo: () -> Unit = {},
     navigateToSocial: () -> Unit = {},
+    navigateToPrivacyPolicy: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val currentAppVersion = remember { getAppVersion(context) }
@@ -201,6 +204,7 @@ fun MyPageDefaultScreen(
         )
         MyPageMenuItem(
             titleText = stringResource(com.susu.feature.mypage.R.string.mypage_privacy_policy),
+            onMenuClick = navigateToPrivacyPolicy,
         )
 
         MyPageDivider()

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/main/MyPageDefaultScreen.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/main/MyPageDefaultScreen.kt
@@ -205,7 +205,11 @@ fun MyPageDefaultScreen(
         MyPageMenuItem(
             titleText = stringResource(com.susu.feature.mypage.R.string.mypage_app_version),
             action = {
-                Text(text = stringResource(com.susu.feature.mypage.R.string.mypage_update), style = SusuTheme.typography.title_xxs, color = Gray60)
+                Text(
+                    text = stringResource(com.susu.feature.mypage.R.string.mypage_update),
+                    style = SusuTheme.typography.title_xxs,
+                    color = Gray60,
+                )
             },
         )
 
@@ -244,9 +248,7 @@ fun MyPageDefaultScreen(
 
 private fun getAppVersion(context: Context): String {
     try {
-        val packageInfo = context.packageManager.getPackageInfo(
-            context.packageName, 0,
-        )
+        val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
 
         if (packageInfo != null) {
             return packageInfo.versionName

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/main/MyPageDefaultScreen.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/main/MyPageDefaultScreen.kt
@@ -30,7 +30,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.susu.core.designsystem.component.appbar.SusuDefaultAppBar
 import com.susu.core.designsystem.component.appbar.icon.LogoIcon
-import com.susu.core.designsystem.component.appbar.icon.NotificationIcon
 import com.susu.core.designsystem.component.button.GhostButtonColor
 import com.susu.core.designsystem.component.button.SmallButtonStyle
 import com.susu.core.designsystem.component.button.SusuGhostButton
@@ -160,7 +159,6 @@ fun MyPageDefaultScreen(
         SusuDefaultAppBar(
             modifier = Modifier.padding(SusuTheme.spacing.spacing_xs),
             leftIcon = { LogoIcon() },
-            actions = { NotificationIcon() },
         )
 
         MyPageMenuItem(

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/main/MyPageDefaultScreen.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/main/MyPageDefaultScreen.kt
@@ -1,5 +1,6 @@
 package com.susu.feature.mypage.main
 
+import android.content.Context
 import android.os.Environment
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -150,8 +151,11 @@ fun MyPageDefaultScreen(
     navigateToInfo: () -> Unit = {},
     navigateToSocial: () -> Unit = {},
 ) {
+    val context = LocalContext.current
     Column(
-        modifier = Modifier.fillMaxSize().padding(padding),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding),
     ) {
         SusuDefaultAppBar(
             modifier = Modifier.padding(SusuTheme.spacing.spacing_xs),
@@ -218,14 +222,15 @@ fun MyPageDefaultScreen(
             onMenuClick = onWithdraw,
         )
         Box(
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
                 .weight(1f)
                 .background(color = Gray20)
                 .padding(SusuTheme.spacing.spacing_m),
         ) {
             Text(
                 modifier = Modifier.align(Alignment.TopStart),
-                text = stringResource(com.susu.feature.mypage.R.string.mypage_app_version) + uiState.appVersion,
+                text = stringResource(com.susu.feature.mypage.R.string.mypage_app_version) + " ${getAppVersion(context)}",
                 style = SusuTheme.typography.title_xxxs,
                 color = Gray50,
             )
@@ -237,6 +242,21 @@ fun MyPageDefaultScreen(
             )
         }
     }
+}
+
+private fun getAppVersion(context: Context): String {
+    try {
+        val packageInfo = context.packageManager.getPackageInfo(
+            context.packageName, 0,
+        )
+
+        if (packageInfo != null) {
+            return packageInfo.versionName
+        }
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
+    return ""
 }
 
 @Composable

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/main/MyPageDefaultScreen.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/main/MyPageDefaultScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -151,6 +152,8 @@ fun MyPageDefaultScreen(
     navigateToSocial: () -> Unit = {},
 ) {
     val context = LocalContext.current
+    val currentAppVersion = remember { getAppVersion(context) }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -232,7 +235,7 @@ fun MyPageDefaultScreen(
         ) {
             Text(
                 modifier = Modifier.align(Alignment.TopStart),
-                text = stringResource(com.susu.feature.mypage.R.string.mypage_app_version) + " ${getAppVersion(context)}",
+                text = stringResource(com.susu.feature.mypage.R.string.mypage_app_version) + " $currentAppVersion",
                 style = SusuTheme.typography.title_xxxs,
                 color = Gray50,
             )
@@ -246,18 +249,10 @@ fun MyPageDefaultScreen(
     }
 }
 
-private fun getAppVersion(context: Context): String {
-    try {
-        val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-
-        if (packageInfo != null) {
-            return packageInfo.versionName
-        }
-    } catch (e: Exception) {
-        e.printStackTrace()
-    }
-    return ""
-}
+private fun getAppVersion(context: Context): String = runCatching {
+    val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+    packageInfo.versionName
+}.getOrNull() ?: ""
 
 @Composable
 fun MyPageDivider(

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/main/component/MyPageMenuItem.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/main/component/MyPageMenuItem.kt
@@ -40,7 +40,12 @@ fun MyPageMenuItem(
             .padding(padding),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(modifier = Modifier.weight(1f), text = titleText, style = titleTextStyle, color = titleTextColor)
+        Text(
+            modifier = Modifier.weight(1f),
+            text = titleText,
+            style = titleTextStyle,
+            color = titleTextColor,
+        )
         action?.let {
             Spacer(modifier = Modifier.width(actionItemPadding))
             it()

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/navigation/MyPageNavigation.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/navigation/MyPageNavigation.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.susu.core.ui.DialogToken
 import com.susu.core.ui.SnackbarToken
+import com.susu.feature.mypage.MyPagePrivacyPolicyScreen
 import com.susu.feature.mypage.info.MyPageInfoRoute
 import com.susu.feature.mypage.main.MyPageDefaultRoute
 import com.susu.feature.mypage.social.MyPageSocialRoute
@@ -23,11 +24,16 @@ fun NavController.navigateMyPageSocial() {
     navigate(MyPageRoute.socialRoute)
 }
 
+fun NavController.navigateMyPagePrivacyPolicy() {
+    navigate(MyPageRoute.privacyPolicyRoute)
+}
+
 fun NavGraphBuilder.myPageNavGraph(
     padding: PaddingValues,
     navigateToLogin: () -> Unit,
     navigateToInfo: () -> Unit,
     navigateToSocial: () -> Unit,
+    navigateToPrivacyPolicy: () -> Unit,
     popBackStack: () -> Unit,
     onShowSnackbar: (SnackbarToken) -> Unit,
     onShowDialog: (DialogToken) -> Unit,
@@ -39,6 +45,7 @@ fun NavGraphBuilder.myPageNavGraph(
             navigateToLogin = navigateToLogin,
             navigateToInfo = navigateToInfo,
             navigateToSocial = navigateToSocial,
+            navigateToPrivacyPolicy = navigateToPrivacyPolicy,
             onShowSnackbar = onShowSnackbar,
             onShowDialog = onShowDialog,
             handleException = handleException,
@@ -55,10 +62,14 @@ fun NavGraphBuilder.myPageNavGraph(
     composable(route = MyPageRoute.socialRoute) {
         MyPageSocialRoute(padding = padding, popBackStack = popBackStack)
     }
+    composable(route = MyPageRoute.privacyPolicyRoute) {
+        MyPagePrivacyPolicyScreen()
+    }
 }
 
 object MyPageRoute {
     const val defaultRoute = "my-page"
     const val infoRoute = "info"
     const val socialRoute = "social"
+    const val privacyPolicyRoute = "privacy-policy"
 }

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/social/MyPageSocialScreen.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/social/MyPageSocialScreen.kt
@@ -69,8 +69,6 @@ fun MyPageSocialScreen(
                 SocialProvider(
                     isActive = when (it) {
                         SnsProviders.Kakao -> AuthApiClient.instance.hasToken()
-                        SnsProviders.Naver -> false
-                        SnsProviders.Google -> false
                     },
                     snsProviders = it,
                 )

--- a/feature/mypage/src/main/res/values/strings.xml
+++ b/feature/mypage/src/main/res/values/strings.xml
@@ -27,4 +27,5 @@
     <string name="mypage_social_when_problem">로그인에 문제가 있다면 팀 옥수수에게 알려주세요</string>
     <string name="mypage_social_question">문의 남기기</string>
     <string name="mypage_my_info_profile">프로필 이미지</string>
+    <string name="mypage_my_info_snackbar_invalid_name">이름은 한글 또는 영문 10글자로 입력해주세요</string>
 </resources>

--- a/feature/navigator/src/main/java/com/susu/feature/navigator/MainNavigator.kt
+++ b/feature/navigator/src/main/java/com/susu/feature/navigator/MainNavigator.kt
@@ -14,6 +14,7 @@ import com.susu.feature.community.navigation.navigateCommunity
 import com.susu.feature.loginsignup.navigation.LoginSignupRoute
 import com.susu.feature.mypage.navigation.navigateMyPage
 import com.susu.feature.mypage.navigation.navigateMyPageInfo
+import com.susu.feature.mypage.navigation.navigateMyPagePrivacyPolicy
 import com.susu.feature.mypage.navigation.navigateMyPageSocial
 import com.susu.feature.received.navigation.ReceivedRoute
 import com.susu.feature.received.navigation.argument.FilterArgument
@@ -148,6 +149,10 @@ internal class MainNavigator(
 
     fun navigateMyPageSocial() {
         navController.navigateMyPageSocial()
+    }
+
+    fun navigateMyPagePrivacyPolicy() {
+        navController.navigateMyPagePrivacyPolicy()
     }
 
     fun navigateReceivedEnvelopeAdd() {

--- a/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
+++ b/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
@@ -134,6 +134,7 @@ internal fun MainScreen(
                     navigateToLogin = navigator::navigateLogin,
                     navigateToInfo = navigator::navigateMyPageInfo,
                     navigateToSocial = navigator::navigateMyPageSocial,
+                    navigateToPrivacyPolicy = navigator::navigateMyPagePrivacyPolicy,
                     popBackStack = navigator::popBackStackIfNotHome,
                     onShowSnackbar = viewModel::onShowSnackbar,
                     onShowDialog = viewModel::onShowDialog,


### PR DESCRIPTION
## 💡 Issue
- Resolved: #82 

## 🌱 Key changes
- 내 정보 편집 수정사항 반영
    - 이름이 형식에 맞지 않는 경우 빨간 점 표시
    - 이름이 형식에 맞지 않고 등록을 누르면 스낵바 표시
    - 출생년도 '미선택' 옵션 추가
- 현재 앱 버전 표시
- 기타 소소한 수정사항
    - 연동된 소셜계정의 네이버, 구글 아이콘 삭제 
    - 기획 삭제에 따른 상단 앱바 알림 아이콘 삭제

## ✅ To Reviewers
- ~~개인정보처리방침은 노션 웹뷰 이슈로 추후 따로 작업 예정~~
    - 개인정보처리방침 웹 페이지 변경 후 이번 PR에 반영했습니다! 
- 앱 최신버전 확인, 업데이트 하러가기는 서버에서 내려주면 작업 예정

## 📸 스크린샷


https://github.com/YAPP-Github/oksusu-susu-android/assets/69582122/50a65823-3099-418a-b34a-d9a64e1b7512

