### PR TITLE
Qa/12 13 ledger card radius cursor layer

### DIFF
--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfieldbutton/SusuTextFieldButton.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfieldbutton/SusuTextFieldButton.kt
@@ -114,10 +114,6 @@ fun SusuTextFieldFillMaxButton(
                         modifier = Modifier.weight(1f),
                         contentAlignment = Alignment.Center,
                     ) {
-                        if (isSaved.not()) {
-                            innerTextField()
-                        }
-
                         /**
                          * Problem : innerTextField 수정 중에 saved가 되면 underline이 생기는 현상.
                          * Solution : saved 상태에서는 Text 컴포저블 함수가 보이게 함.
@@ -144,6 +140,10 @@ fun SusuTextFieldFillMaxButton(
                                 maxLines = maxLines,
                                 minLines = minLines,
                             )
+                        }
+
+                        if (isSaved.not()) {
+                            innerTextField()
                         }
                     }
 
@@ -213,6 +213,18 @@ fun SusuTextFieldWrapContentButton(
             Box(
                 contentAlignment = Alignment.Center,
             ) {
+                if (text.isEmpty()) {
+                    Text(
+                        text = placeholder,
+                        color = color.placeholderColor,
+                        style = textStyle,
+                        textAlign = TextAlign.Center,
+                        overflow = overflow,
+                        maxLines = maxLines,
+                        minLines = minLines,
+                    )
+                }
+
                 BasicTextField(
                     modifier = Modifier
                         .disabledHorizontalPointerInputScroll()
@@ -254,18 +266,6 @@ fun SusuTextFieldWrapContentButton(
                         innerTextField()
                     },
                 )
-
-                if (text.isEmpty()) {
-                    Text(
-                        text = placeholder,
-                        color = color.placeholderColor,
-                        style = textStyle,
-                        textAlign = TextAlign.Center,
-                        overflow = overflow,
-                        maxLines = maxLines,
-                        minLines = minLines,
-                    )
-                }
             }
 
             InnerButtons(

--- a/feature/received/src/main/java/com/susu/feature/received/received/component/LedgerAddCard.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/received/component/LedgerAddCard.kt
@@ -5,10 +5,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalDensity
@@ -37,6 +39,7 @@ fun LedgerAddCard(
 
     Box(
         modifier = modifier
+            .clip(RoundedCornerShape(4.dp))
             .aspectRatio(1f)
             .susuClickable(onClick = onClick),
     ) {

--- a/feature/received/src/main/java/com/susu/feature/received/received/component/LedgerCard.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/received/component/LedgerCard.kt
@@ -6,11 +6,14 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.susu.core.designsystem.component.badge.BadgeColor
 import com.susu.core.designsystem.component.badge.BadgeStyle
 import com.susu.core.designsystem.component.badge.SusuBadge
@@ -35,6 +38,7 @@ fun LedgerCard(
 
     Column(
         modifier = modifier
+            .clip(RoundedCornerShape(4.dp))
             .aspectRatio(1f)
             .background(Gray10)
             .susuClickable(onClick = onClick)


### PR DESCRIPTION
## 💡 Issue
- Resolved: #133

## 🌱 Key changes
<!--변경사항 적기-->
- 받아요 장부 radius 미적용 적용 필요
- 투표 작성 페이지 보기 작성 button 커서 레이어 가장 위로 변경

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->

## 📸 스크린샷
|스크린샷|스크린샷|
|:--:|:--:|
|![image](https://github.com/YAPP-Github/oksusu-susu-android/assets/81678959/1379def1-3ec2-427c-9a46-fb20331dd102)|![image](https://github.com/YAPP-Github/oksusu-susu-android/assets/81678959/9e4edadf-6717-4e2f-b6b2-37e68ad92ff7)|
