### PR TITLE
QA-6/보내요 봉투 수정사항이 받아요 화면에 반영이 되지 않는 현상

### DIFF
--- a/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
+++ b/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
@@ -88,6 +88,13 @@ internal fun MainScreen(
                         )
                         navigator.popBackStackIfNotHome()
                     },
+                    popBackStackWithEditedFriendId = { friendId ->
+                        navigator.navController.previousBackStackEntry?.savedStateHandle?.set(
+                            SentRoute.EDITED_FRIEND_ID_ARGUMENT_NAME,
+                            friendId,
+                        )
+                        navigator.popBackStackIfNotHome()
+                    },
                     popBackStackWithRefresh = {
                         navigator.navController.previousBackStackEntry?.savedStateHandle?.set(
                             SentRoute.SENT_REFRESH_ARGUMENT_NAME,

--- a/feature/sent/src/main/java/com/susu/feature/envelope/SentEnvelopeScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelope/SentEnvelopeScreen.kt
@@ -1,5 +1,6 @@
 package com.susu.feature.envelope
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -50,6 +51,8 @@ fun SentEnvelopeRoute(
     viewModel: SentEnvelopeViewModel = hiltViewModel(),
     popBackStack: () -> Unit,
     popBackStackWithDeleteFriendId: (Long) -> Unit,
+    popBackStackWithEditedFriendId: (Long) -> Unit,
+    editedFriendId: Long?,
     navigateSentEnvelopeDetail: (Long) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
@@ -57,7 +60,10 @@ fun SentEnvelopeRoute(
 
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
-            SentEnvelopeSideEffect.PopBackStack -> popBackStack()
+            SentEnvelopeSideEffect.PopBackStack -> {
+                editedFriendId?.let { popBackStackWithEditedFriendId(it) } ?: popBackStack()
+            }
+
             is SentEnvelopeSideEffect.NavigateEnvelopeDetail -> navigateSentEnvelopeDetail(sideEffect.id)
             is SentEnvelopeSideEffect.PopBackStackWithDeleteFriendId -> popBackStackWithDeleteFriendId(sideEffect.id)
         }
@@ -69,6 +75,10 @@ fun SentEnvelopeRoute(
 
     historyListState.OnBottomReached {
         viewModel.getEnvelopeHistoryList()
+    }
+
+    BackHandler {
+        editedFriendId?.let { popBackStackWithEditedFriendId(it) } ?: popBackStack()
     }
 
     SentEnvelopeScreen(

--- a/feature/sent/src/main/java/com/susu/feature/envelopedetail/SentEnvelopeDetailScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopedetail/SentEnvelopeDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.susu.feature.envelopedetail
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -38,6 +39,8 @@ import kotlinx.datetime.toJavaLocalDateTime
 fun SentEnvelopeDetailRoute(
     viewModel: SentEnvelopeDetailViewModel = hiltViewModel(),
     popBackStack: () -> Unit,
+    popBackStackWithEditedFriendId: (Long) -> Unit,
+    editedFriendId: Long?,
     navigateSentEnvelopeEdit: (EnvelopeDetail) -> Unit,
     onShowSnackbar: (SnackbarToken) -> Unit,
     onShowDialog: (DialogToken) -> Unit,
@@ -48,7 +51,9 @@ fun SentEnvelopeDetailRoute(
 
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
-            SentEnvelopeDetailEffect.PopBackStack -> popBackStack()
+            SentEnvelopeDetailEffect.PopBackStack -> {
+                editedFriendId?.let { popBackStackWithEditedFriendId(it) } ?: popBackStack()
+            }
             is SentEnvelopeDetailEffect.NavigateEnvelopeEdit -> navigateSentEnvelopeEdit(sideEffect.envelopeDetail)
             SentEnvelopeDetailEffect.ShowDeleteDialog -> onShowDialog(
                 DialogToken(
@@ -72,6 +77,10 @@ fun SentEnvelopeDetailRoute(
 
     LaunchedEffect(key1 = Unit) {
         viewModel.getEnvelopeDetail()
+    }
+
+    BackHandler {
+        editedFriendId?.let { popBackStackWithEditedFriendId(it) } ?: popBackStack()
     }
 
     SentEnvelopeDetailScreen(

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditContract.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditContract.kt
@@ -33,6 +33,7 @@ data class SentEnvelopeEditState(
 
 sealed interface SentEnvelopeEditSideEffect : SideEffect {
     data object PopBackStack : SentEnvelopeEditSideEffect
+    data class PopBackStackWithEditedFriendId(val id: Long) : SentEnvelopeEditSideEffect
     data class HandleException(val throwable: Throwable, val retry: () -> Unit) : SentEnvelopeEditSideEffect
     data object FocusCustomCategory : SentEnvelopeEditSideEffect
     data object FocusCustomRelationship : SentEnvelopeEditSideEffect

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
@@ -62,6 +62,7 @@ import kotlinx.coroutines.launch
 fun SentEnvelopeEditRoute(
     viewModel: SentEnvelopeEditViewModel = hiltViewModel(),
     popBackStack: () -> Unit,
+    popBackStackWithEditedFriendId: (Long) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val categoryFocusRequester = remember { FocusRequester() }
@@ -85,6 +86,8 @@ fun SentEnvelopeEditRoute(
                     relationshipFocusRequester.requestFocus()
                 }
             }
+
+            is SentEnvelopeEditSideEffect.PopBackStackWithEditedFriendId -> popBackStackWithEditedFriendId(sideEffect.id)
         }
     }
 

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditViewModel.kt
@@ -89,7 +89,7 @@ class SentEnvelopeEditViewModel @Inject constructor(
                     )
                 },
             ).onSuccess {
-                popBackStack()
+                postSideEffect(SentEnvelopeEditSideEffect.PopBackStackWithEditedFriendId(it.friend.id))
             }.onFailure {
                 postSideEffect(SentEnvelopeEditSideEffect.HandleException(it, ::editEnvelope))
             }

--- a/feature/sent/src/main/java/com/susu/feature/sent/SentContract.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/SentContract.kt
@@ -32,11 +32,12 @@ data class FriendStatisticsState(
     val expand: Boolean = false,
 )
 
-internal fun FriendStatistics.toState() = FriendStatisticsState(
+internal fun FriendStatistics.toState(expand: Boolean = false) = FriendStatisticsState(
     friend = friend,
     receivedAmounts = receivedAmounts,
     sentAmounts = sentAmounts,
     totalAmounts = totalAmounts,
+    expand = expand,
 )
 
 enum class EnvelopeAlign(

--- a/feature/sent/src/main/java/com/susu/feature/sent/SentScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/SentScreen.kt
@@ -95,6 +95,9 @@ fun SentRoute(
         }
         viewModel.getEnvelopesList(refresh)
         viewModel.filterIfNeed(filter)
+        if (editedFriendId != null) {
+            viewModel.editFriendStatistics(editedFriendId)
+        }
     }
 
     envelopesListState.OnBottomReached {

--- a/feature/sent/src/main/java/com/susu/feature/sent/SentScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/SentScreen.kt
@@ -63,6 +63,7 @@ import me.onebone.toolbar.rememberCollapsingToolbarScaffoldState
 fun SentRoute(
     viewModel: SentViewModel = hiltViewModel(),
     deletedFriendId: Long?,
+    editedFriendId: Long?,
     refresh: Boolean?,
     filter: String?,
     padding: PaddingValues,

--- a/feature/sent/src/main/java/com/susu/feature/sent/SentScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/SentScreen.kt
@@ -111,8 +111,12 @@ fun SentRoute(
         onClickHistoryShowAll = viewModel::navigateSentEnvelope,
         onClickAddEnvelope = viewModel::navigateSentAdd,
         onClickSearchIcon = viewModel::navigateSentEnvelopeSearch,
-        onClickHistory = { friendId ->
-            viewModel.getEnvelopesHistoryList(friendId)
+        onClickHistory = { expand, friendId ->
+            if (expand) {
+                viewModel.hideEnvelopesHistoryList(friendId)
+            } else { // history 열려 있을 경우 데이터 요청
+                viewModel.getEnvelopesHistoryList(friendId)
+            }
         },
         onClickFilterButton = viewModel::navigateEnvelopeFilter,
         onClickFriendClose = viewModel::unselectFriend,
@@ -130,7 +134,7 @@ fun SentScreen(
     envelopesListState: LazyListState = rememberLazyListState(),
     padding: PaddingValues,
     onClickSearchIcon: () -> Unit = {},
-    onClickHistory: (Long) -> Unit = {},
+    onClickHistory: (Boolean, Long) -> Unit = { _, _ -> },
     onClickHistoryShowAll: (Long) -> Unit = {},
     onClickAddEnvelope: () -> Unit = {},
     onClickFilterButton: () -> Unit = {},

--- a/feature/sent/src/main/java/com/susu/feature/sent/SentViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/SentViewModel.kt
@@ -113,6 +113,20 @@ class SentViewModel @Inject constructor(
         }
     }
 
+    fun hideEnvelopesHistoryList(id: Long) {
+        intent {
+            copy(
+                envelopesList = envelopesList.map {
+                    if (it.friend.id == id) {
+                        it.copy(expand = false)
+                    } else {
+                        it
+                    }
+                }.toPersistentList(),
+            )
+        }
+    }
+
     fun deleteEmptyFriendStatistics(id: Long) {
         val filteredList = currentState.envelopesList.filter {
             it.friend.id != id

--- a/feature/sent/src/main/java/com/susu/feature/sent/SentViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/SentViewModel.kt
@@ -102,7 +102,7 @@ class SentViewModel @Inject constructor(
                         if (it.friend.id == id) {
                             it.copy(
                                 envelopesHistoryList = newEnvelopesHistoryList,
-                                expand = !it.expand,
+                                expand = true,
                             )
                         } else {
                             it
@@ -119,6 +119,34 @@ class SentViewModel @Inject constructor(
         }.toPersistentList()
 
         intent { copy(envelopesList = filteredList) }
+    }
+
+    fun editFriendStatistics(id: Long) = viewModelScope.launch {
+        getEnvelopesListUseCase(
+            GetEnvelopesListUseCase.Param(
+                friendIds = listOf(id),
+            ),
+        ).onSuccess { list ->
+            val friendStatistics = list.firstOrNull() ?: return@launch
+            val editedEnvelopeList = currentState.envelopesList.map {
+                if (it.friend.id == id) {
+                    it.copy(
+                        receivedAmounts = friendStatistics.receivedAmounts,
+                        sentAmounts = friendStatistics.sentAmounts,
+                        totalAmounts = friendStatistics.totalAmounts,
+                        expand = true,
+                    )
+                } else {
+                    it
+                }
+            }.toPersistentList()
+
+            intent {
+                copy(envelopesList = editedEnvelopeList)
+            }
+
+            getEnvelopesHistoryList(id)
+        }
     }
 
     fun navigateSentEnvelope(id: Long) = postSideEffect(SentEffect.NavigateEnvelope(id = id))

--- a/feature/sent/src/main/java/com/susu/feature/sent/component/SentCard.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/component/SentCard.kt
@@ -52,7 +52,6 @@ fun SentCard(
     onClickHistoryShowAll: (Long) -> Unit = {},
 ) {
     val degrees by animateFloatAsState(if (state.expand) 180f else 0f, label = "")
-
     Box(
         modifier = Modifier
             .clip(shape = RoundedCornerShape(4.dp))

--- a/feature/sent/src/main/java/com/susu/feature/sent/component/SentCard.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/component/SentCard.kt
@@ -48,7 +48,7 @@ import com.susu.feature.sent.R
 @Composable
 fun SentCard(
     state: FriendStatisticsState = FriendStatisticsState(),
-    onClickHistory: (Long) -> Unit = {},
+    onClickHistory: (Boolean, Long) -> Unit = { _, _ -> },
     onClickHistoryShowAll: (Long) -> Unit = {},
 ) {
     val degrees by animateFloatAsState(if (state.expand) 180f else 0f, label = "")
@@ -92,7 +92,7 @@ fun SentCard(
                         .clip(CircleShape)
                         .susuClickable(
                             onClick = {
-                                onClickHistory(state.friend.id)
+                                onClickHistory(state.expand, state.friend.id)
                             },
                         )
                         .rotate(degrees = degrees),

--- a/feature/sent/src/main/java/com/susu/feature/sent/navigation/SentNavigation.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/navigation/SentNavigation.kt
@@ -52,6 +52,7 @@ fun NavGraphBuilder.sentNavGraph(
     padding: PaddingValues,
     popBackStack: () -> Unit,
     popBackStackWithDeleteFriendId: (Long) -> Unit,
+    popBackStackWithEditedFriendId: (Long) -> Unit,
     popBackStackWithRefresh: () -> Unit,
     navigateSentEnvelope: (Long) -> Unit,
     navigateSentEnvelopeDetail: (Long) -> Unit,
@@ -66,15 +67,18 @@ fun NavGraphBuilder.sentNavGraph(
 ) {
     composable(route = SentRoute.route) { navBackStackEntry ->
         val deletedFriendId = navBackStackEntry.savedStateHandle.get<Long>(SentRoute.FRIEND_ID_ARGUMENT_NAME)
+        val editedFriendId = navBackStackEntry.savedStateHandle.get<Long>(SentRoute.EDITED_FRIEND_ID_ARGUMENT_NAME)
         val refresh = navBackStackEntry.savedStateHandle.get<Boolean>(SentRoute.SENT_REFRESH_ARGUMENT_NAME)
         val filter = navBackStackEntry.savedStateHandle.get<String>(SentRoute.FILTER_ENVELOPE_ARGUMENT)
         navBackStackEntry.savedStateHandle.set<String>(SentRoute.FILTER_ENVELOPE_ARGUMENT, null)
         navBackStackEntry.savedStateHandle.set<Boolean>(SentRoute.SENT_REFRESH_ARGUMENT_NAME, null)
+        navBackStackEntry.savedStateHandle.set<Long>(SentRoute.EDITED_FRIEND_ID_ARGUMENT_NAME, null)
 
         SentRoute(
             padding = padding,
             filter = filter,
             deletedFriendId = deletedFriendId,
+            editedFriendId = editedFriendId,
             refresh = refresh,
             navigateSentEnvelope = navigateSentEnvelope,
             navigateSentEnvelopeAdd = navigateSentEnvelopeAdd,
@@ -90,9 +94,12 @@ fun NavGraphBuilder.sentNavGraph(
                 type = NavType.LongType
             },
         ),
-    ) {
+    ) { navBackStackEntry ->
+        val editedFriendId = navBackStackEntry.savedStateHandle.get<Long>(SentRoute.EDITED_FRIEND_ID_ARGUMENT_NAME)
         SentEnvelopeRoute(
             popBackStack = popBackStack,
+            editedFriendId = editedFriendId,
+            popBackStackWithEditedFriendId = popBackStackWithEditedFriendId,
             navigateSentEnvelopeDetail = navigateSentEnvelopeDetail,
             popBackStackWithDeleteFriendId = popBackStackWithDeleteFriendId,
         )
@@ -105,9 +112,13 @@ fun NavGraphBuilder.sentNavGraph(
                 type = NavType.LongType
             },
         ),
-    ) {
+    ) { navBackStackEntry ->
+        val editedFriendId = navBackStackEntry.savedStateHandle.get<Long>(SentRoute.EDITED_FRIEND_ID_ARGUMENT_NAME)
+
         SentEnvelopeDetailRoute(
             popBackStack = popBackStack,
+            editedFriendId = editedFriendId,
+            popBackStackWithEditedFriendId = popBackStackWithEditedFriendId,
             navigateSentEnvelopeEdit = navigateSentEnvelopeEdit,
             onShowSnackbar = onShowSnackbar,
             onShowDialog = onShowDialog,
@@ -118,6 +129,7 @@ fun NavGraphBuilder.sentNavGraph(
     composable(route = SentRoute.sentEnvelopeEditRoute("{${SentRoute.ENVELOPE_DETAIL_ARGUMENT_NAME}}")) {
         SentEnvelopeEditRoute(
             popBackStack = popBackStack,
+            popBackStackWithEditedFriendId = popBackStackWithEditedFriendId,
         )
     }
 
@@ -153,6 +165,7 @@ object SentRoute {
     const val SENT_REFRESH_ARGUMENT_NAME = "sent-refresh"
     fun sentEnvelopeRoute(id: String) = "sent-envelope/$id"
     const val FRIEND_ID_ARGUMENT_NAME = "sent-envelope-id"
+    const val EDITED_FRIEND_ID_ARGUMENT_NAME = "edited-friend-id"
 
     fun sentEnvelopeDetailRoute(id: String) = "sent-envelope-detail/$id"
     const val ENVELOPE_ID_ARGUMENT_NAME = "sent-envelope-detail-id"


### PR DESCRIPTION
## 💡 Issue
- Resolved: #132 

## 🌱 Key changes
- [보내요 봉투 편집]에서 편집 성공 시 `친구id`를 [보내요] 화면까지 전달합니다.
    - 2개의 스탭을 건너서 데이터를 전달할 더 좋은 방법이 있을까요?
- [보내요]에서 편집된 친구의 `FriendStatistic`을 서버에서 받아와 갱신합니다.
    - 받은 금액, 보낸 금액, 총액을 로컬에서 계산할 수는 있지만... 복잡해질 것 같아 서버에서 새로 받아와 처리했습니다.
-  봉투 히스토리를 닫을 때에도 api를 호출하고 있는 부분을 히스토리를 열 때만 api를 호출하도록 수정했습니다.


## 📸 스크린샷


https://github.com/YAPP-Github/oksusu-susu-android/assets/69582122/14e7ca0f-fd0b-4a23-aa66-ce8b5fa9b472

