### PR TITLE
Qa/34 로그아웃 후 다른 계정으로 로그인 시, 이전 계정의 데이터가 노출되는 현상

### DIFF
--- a/data/src/main/java/com/susu/data/Constants.kt
+++ b/data/src/main/java/com/susu/data/Constants.kt
@@ -1,0 +1,10 @@
+package com.susu.data
+
+import androidx.datastore.preferences.core.booleanPreferencesKey
+
+object Constants {
+    const val RETROFIT_TAG = "Retrofit"
+
+    private const val SHOW_ONBOARD_VOTE = "Onboarding"
+    val showOnboardingVoteKey = booleanPreferencesKey(SHOW_ONBOARD_VOTE)
+}

--- a/data/src/main/java/com/susu/data/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/susu/data/data/repository/LoginRepositoryImpl.kt
@@ -1,5 +1,10 @@
 package com.susu.data.data.repository
 
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import com.susu.core.model.Token
+import com.susu.data.Constants
 import com.susu.data.remote.api.AuthService
 import com.susu.data.remote.model.request.AccessTokenRequest
 import com.susu.data.remote.model.response.toDomain
@@ -8,12 +13,18 @@ import javax.inject.Inject
 
 class LoginRepositoryImpl @Inject constructor(
     private val authService: AuthService,
+    private val dataStore: DataStore<Preferences>,
 ) : LoginRepository {
     override suspend fun login(
         provider: String,
         oauthAccessToken: String,
-    ) = authService.login(
-        provider = provider,
-        accessTokenRequest = AccessTokenRequest(oauthAccessToken),
-    ).getOrThrow().toDomain()
+    ): Token {
+        dataStore.edit { preferences ->
+            preferences[Constants.showOnboardingVoteKey] = false
+        }
+        return authService.login(
+            provider = provider,
+            accessTokenRequest = AccessTokenRequest(oauthAccessToken),
+        ).getOrThrow().toDomain()
+    }
 }

--- a/data/src/main/java/com/susu/data/data/repository/SignUpRepositoryImpl.kt
+++ b/data/src/main/java/com/susu/data/data/repository/SignUpRepositoryImpl.kt
@@ -1,25 +1,38 @@
 package com.susu.data.data.repository
 
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
 import com.susu.core.model.SignUpUser
+import com.susu.core.model.Token
+import com.susu.data.Constants.showOnboardingVoteKey
 import com.susu.data.remote.api.SignUpService
 import com.susu.data.remote.model.request.toData
 import com.susu.data.remote.model.response.toDomain
 import com.susu.domain.repository.SignUpRepository
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class SignUpRepositoryImpl @Inject constructor(
     private val signUpService: SignUpService,
+    private val dataStore: DataStore<Preferences>,
 ) : SignUpRepository {
 
     override suspend fun signUp(
         provider: String,
         oauthAccessToken: String,
         signUpUser: SignUpUser,
-    ) = signUpService.signUp(
-        provider = provider,
-        accessToken = oauthAccessToken,
-        user = signUpUser.toData(),
-    ).getOrThrow().toDomain()
+    ): Token {
+        dataStore.edit { preferences ->
+            preferences[showOnboardingVoteKey] = false
+        }
+        return signUpService.signUp(
+            provider = provider,
+            accessToken = oauthAccessToken,
+            user = signUpUser.toData(),
+        ).getOrThrow().toDomain()
+    }
 
     override suspend fun canRegister(
         provider: String,
@@ -29,5 +42,11 @@ class SignUpRepositoryImpl @Inject constructor(
             provider = provider,
             accessToken = oauthAccessToken,
         ).getOrThrow().canRegister
+    }
+
+    override suspend fun getShowOnboardVote(): Boolean? {
+        return dataStore.data.map { preferences ->
+            preferences[showOnboardingVoteKey]
+        }.firstOrNull()
     }
 }

--- a/data/src/main/java/com/susu/data/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/susu/data/data/repository/UserRepositoryImpl.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.susu.core.model.User
 import com.susu.core.model.exception.UserNotFoundException
+import com.susu.data.Constants.showOnboardingVoteKey
 import com.susu.data.remote.api.AuthService
 import com.susu.data.remote.api.UserService
 import com.susu.data.remote.model.request.UserPatchRequest
@@ -63,6 +64,7 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun withdraw() {
         dataStore.edit { preferences ->
             preferences.remove(userKey)
+            preferences.remove(showOnboardingVoteKey)
         }
         authService.withdraw().getOrThrow()
     }

--- a/data/src/main/java/com/susu/data/remote/Constants.kt
+++ b/data/src/main/java/com/susu/data/remote/Constants.kt
@@ -1,5 +1,0 @@
-package com.susu.data.remote
-
-object Constants {
-    const val RETROFIT_TAG = "Retrofit"
-}

--- a/data/src/main/java/com/susu/data/remote/di/NetworkModule.kt
+++ b/data/src/main/java/com/susu/data/remote/di/NetworkModule.kt
@@ -1,7 +1,7 @@
 package com.susu.data.remote.di
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
-import com.susu.data.remote.Constants.RETROFIT_TAG
+import com.susu.data.Constants.RETROFIT_TAG
 import com.susu.data.remote.network.TokenAuthenticator
 import com.susu.data.remote.network.TokenInterceptor
 import com.susu.data.remote.retrofit.ResultCallAdapterFactory

--- a/domain/src/main/java/com/susu/domain/repository/SignUpRepository.kt
+++ b/domain/src/main/java/com/susu/domain/repository/SignUpRepository.kt
@@ -6,4 +6,5 @@ import com.susu.core.model.Token
 interface SignUpRepository {
     suspend fun signUp(provider: String, oauthAccessToken: String, signUpUser: SignUpUser): Token
     suspend fun canRegister(provider: String, oauthAccessToken: String): Boolean
+    suspend fun getShowOnboardVote(): Boolean?
 }

--- a/domain/src/main/java/com/susu/domain/usecase/loginsignup/CheckShowOnboardVoteUseCase.kt
+++ b/domain/src/main/java/com/susu/domain/usecase/loginsignup/CheckShowOnboardVoteUseCase.kt
@@ -1,0 +1,13 @@
+package com.susu.domain.usecase.loginsignup
+
+import com.susu.core.common.runCatchingIgnoreCancelled
+import com.susu.domain.repository.SignUpRepository
+import javax.inject.Inject
+
+class CheckShowOnboardVoteUseCase @Inject constructor(
+    private val signUpRepository: SignUpRepository,
+) {
+    suspend operator fun invoke() = runCatchingIgnoreCancelled {
+        signUpRepository.getShowOnboardVote()
+    }.getOrNull()
+}

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/social/KakaoLoginHelper.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/social/KakaoLoginHelper.kt
@@ -1,7 +1,6 @@
 package com.susu.feature.loginsignup.social
 
 import android.content.Context
-import com.kakao.sdk.auth.AuthApiClient
 import com.kakao.sdk.auth.TokenManagerProvider
 import com.kakao.sdk.common.model.AuthError
 import com.kakao.sdk.common.model.ClientError
@@ -10,8 +9,6 @@ import com.kakao.sdk.user.UserApiClient
 import timber.log.Timber
 
 object KakaoLoginHelper {
-    val hasKakaoLoginHistory
-        get() = AuthApiClient.instance.hasToken()
 
     fun login(
         context: Context,

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/main/MyPageDefaultScreen.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/main/MyPageDefaultScreen.kt
@@ -57,7 +57,7 @@ import com.susu.feature.mypage.main.component.MyPageMenuItem
 fun MyPageDefaultRoute(
     padding: PaddingValues,
     viewModel: MyPageViewModel = hiltViewModel(),
-    navigateToLogin: () -> Unit,
+    restartMainActivity: () -> Unit,
     navigateToInfo: () -> Unit,
     navigateToSocial: () -> Unit,
     navigateToPrivacyPolicy: () -> Unit,
@@ -77,7 +77,7 @@ fun MyPageDefaultRoute(
 
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
-            MyPageEffect.NavigateToLogin -> navigateToLogin()
+            MyPageEffect.NavigateToLogin -> restartMainActivity()
             MyPageEffect.NavigateToInfo -> navigateToInfo()
             MyPageEffect.NavigateToSocial -> navigateToSocial()
             is MyPageEffect.ShowSnackbar -> onShowSnackbar(SnackbarToken(message = sideEffect.msg))

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/navigation/MyPageNavigation.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/navigation/MyPageNavigation.kt
@@ -30,7 +30,7 @@ fun NavController.navigateMyPagePrivacyPolicy() {
 
 fun NavGraphBuilder.myPageNavGraph(
     padding: PaddingValues,
-    navigateToLogin: () -> Unit,
+    restartMainActivity: () -> Unit,
     navigateToInfo: () -> Unit,
     navigateToSocial: () -> Unit,
     navigateToPrivacyPolicy: () -> Unit,
@@ -42,7 +42,7 @@ fun NavGraphBuilder.myPageNavGraph(
     composable(route = MyPageRoute.defaultRoute) {
         MyPageDefaultRoute(
             padding = padding,
-            navigateToLogin = navigateToLogin,
+            restartMainActivity = restartMainActivity,
             navigateToInfo = navigateToInfo,
             navigateToSocial = navigateToSocial,
             navigateToPrivacyPolicy = navigateToPrivacyPolicy,

--- a/feature/navigator/src/main/java/com/susu/feature/navigator/MainActivity.kt
+++ b/feature/navigator/src/main/java/com/susu/feature/navigator/MainActivity.kt
@@ -43,7 +43,6 @@ class MainActivity : ComponentActivity() {
         if (uiState.isNavigating) {
             KakaoLoginHelper.getAccessToken { accessToken ->
                 viewModel.navigate(
-                    hasKakaoLoginHistory = KakaoLoginHelper.hasKakaoLoginHistory,
                     kakaoAccessToken = accessToken,
                 )
             }

--- a/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
+++ b/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
@@ -1,5 +1,6 @@
 package com.susu.feature.navigator
 
+import android.content.Intent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
@@ -226,7 +227,12 @@ internal fun MainScreen(
 
                 myPageNavGraph(
                     padding = innerPadding,
-                    navigateToLogin = navigator::navigateLogin,
+                    restartMainActivity = {
+                        val intent = Intent(context, MainActivity::class.java).apply {
+                            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                        }
+                        context.startActivity(intent)
+                    },
                     navigateToInfo = navigator::navigateMyPageInfo,
                     navigateToSocial = navigator::navigateMyPageSocial,
                     navigateToPrivacyPolicy = navigator::navigateMyPagePrivacyPolicy,

--- a/feature/navigator/src/main/java/com/susu/feature/navigator/MainViewModel.kt
+++ b/feature/navigator/src/main/java/com/susu/feature/navigator/MainViewModel.kt
@@ -9,6 +9,7 @@ import com.susu.core.ui.SnsProviders
 import com.susu.core.ui.base.BaseViewModel
 import com.susu.domain.usecase.categoryconfig.GetCategoryConfigUseCase
 import com.susu.domain.usecase.loginsignup.CheckCanRegisterUseCase
+import com.susu.domain.usecase.loginsignup.CheckShowOnboardVoteUseCase
 import com.susu.domain.usecase.loginsignup.LoginUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
@@ -22,6 +23,7 @@ import javax.inject.Inject
 class MainViewModel @Inject constructor(
     private val loginUseCase: LoginUseCase,
     private val checkCanRegisterUseCase: CheckCanRegisterUseCase,
+    private val checkShowOnboardVoteUseCase: CheckShowOnboardVoteUseCase,
     private val getCategoryConfigUseCase: GetCategoryConfigUseCase,
 ) : BaseViewModel<MainState, MainSideEffect>(MainState()) {
     companion object {
@@ -59,8 +61,8 @@ class MainViewModel @Inject constructor(
         intent { copy(isInitializing = false) }
     }
 
-    fun navigate(hasKakaoLoginHistory: Boolean, kakaoAccessToken: String?) = viewModelScope.launch {
-        if (hasKakaoLoginHistory.not()) {
+    fun navigate(kakaoAccessToken: String?) = viewModelScope.launch {
+        if (checkShowOnboardVoteUseCase() == null) {
             intent { copy(isNavigating = false) }
             return@launch
         }


### PR DESCRIPTION

## 🌱 Key changes
- 로그아웃하여 모든 백스택이 제거되어도 compose-navigation의 `saveState`, `restoreState` 옵션으로 이전 계정의 `ViewModel`이 복구되는 문제
    - 로그아웃 시, 기존 액티비티를 새로운 액티비티로 교체하여 기존 계정의 데이터를 싹 날리는 것으로 해결
- 회원가입 투표 노출 기준 변경
    - 기존) 카카오 로그인 history -> 변경) DataStore로 저장된 별개의 flag가 존재하지 않을 시
    - 노출되는 경우
        - 앱을 처음 깔고 실행했을 때
        - 탈퇴했을 때  
    - 기존 구현에선 로그아웃된 상태로 앱 재실행해도 투표가 노출되어서 어차피 노출 기준을 바꿔야만 했네요

## ✅ To Reviewers
- 아이디어, 구현에 도움 주신 진욱님께 무한한 감사를 

