### PR TITLE
Qa/9-10-43 회원가입(약관, 출생년도), 마이페이지(출생년도) 관련 수정

### DIFF
--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/bottomsheet/datepicker/SusuDatePickerBottomSheet.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/bottomsheet/datepicker/SusuDatePickerBottomSheet.kt
@@ -337,12 +337,16 @@ fun SusuYearPickerBottomSheet(
     val currentYear = remember { LocalDate.now().year }
     var selectedYear by remember { mutableIntStateOf(initialYear ?: currentYear) }
     val yearList = if (reverseItemOrder) {
-        (yearRange.reversed()
-            .map { stringResource(id = R.string.word_year_format, it) } +
-            listOf(stringResource(R.string.word_not_select))).toImmutableList()
+        (
+            yearRange.reversed()
+                .map { stringResource(id = R.string.word_year_format, it) } +
+                listOf(stringResource(R.string.word_not_select))
+            ).toImmutableList()
     } else {
-        (yearRange.map { stringResource(id = R.string.word_year_format, it) } +
-            listOf(stringResource(R.string.word_not_select))).toImmutableList()
+        (
+            yearRange.map { stringResource(id = R.string.word_year_format, it) } +
+                listOf(stringResource(R.string.word_not_select))
+            ).toImmutableList()
     }
 
     SusuBottomSheet(

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/bottomsheet/datepicker/SusuDatePickerBottomSheet.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/bottomsheet/datepicker/SusuDatePickerBottomSheet.kt
@@ -324,6 +324,7 @@ fun SusuLimitDatePickerBottomSheet(
 fun SusuYearPickerBottomSheet(
     sheetState: SheetState = rememberModalBottomSheetState(),
     yearRange: IntRange = 1930..2030,
+    reverseItemOrder: Boolean = false,
     initialYear: Int? = null,
     maximumContainerHeight: Dp,
     itemHeight: Dp = 48.dp,
@@ -335,8 +336,15 @@ fun SusuYearPickerBottomSheet(
 ) {
     val currentYear = remember { LocalDate.now().year }
     var selectedYear by remember { mutableIntStateOf(initialYear ?: currentYear) }
-    val yearList =
-        (yearRange.map { stringResource(id = R.string.word_year_format, it) } + listOf(stringResource(R.string.word_not_select))).toImmutableList()
+    val yearList = if (reverseItemOrder) {
+        (yearRange.reversed()
+            .map { stringResource(id = R.string.word_year_format, it) } +
+            listOf(stringResource(R.string.word_not_select))).toImmutableList()
+    } else {
+        (yearRange.map { stringResource(id = R.string.word_year_format, it) } +
+            listOf(stringResource(R.string.word_not_select))).toImmutableList()
+    }
+
     SusuBottomSheet(
         sheetState = sheetState,
         containerHeight = minOf(maximumContainerHeight, itemHeight * numberOfDisplayedItems + 32.dp),

--- a/core/ui/src/main/java/com/susu/core/ui/Consts.kt
+++ b/core/ui/src/main/java/com/susu/core/ui/Consts.kt
@@ -5,6 +5,7 @@ import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import com.susu.core.ui.util.currentDate
 import kotlinx.collections.immutable.persistentListOf
 
 // TODO REMOVE
@@ -22,7 +23,7 @@ val moneyList = persistentListOf(10_000, 30_000, 50_000, 100_000, 500_000)
 const val USER_NAME_MAX_LENGTH = 10
 val nameRegex = Regex("[a-zA-Z가-힣]{0,10}")
 
-val USER_BIRTH_RANGE = 1930..2030
+val USER_BIRTH_RANGE = 1930..currentDate.year
 
 const val INTENT_ACTION_DOWNLOAD_COMPLETE = "android.intent.action.DOWNLOAD_COMPLETE"
 const val PRIVACY_POLICY_URL = "https://sites.google.com/view/team-oksusu/%ED%99%88"

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -38,6 +40,7 @@ import com.susu.core.designsystem.component.button.SusuFilledButton
 import com.susu.core.designsystem.component.screen.LoadingScreen
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.ui.SnackbarToken
+import com.susu.core.ui.USER_BIRTH_RANGE
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.feature.loginsignup.signup.content.AdditionalContent
 import com.susu.feature.loginsignup.signup.content.NameContent
@@ -167,6 +170,8 @@ fun SignUpRoute(
 
         if (showDatePicker) {
             SusuYearPickerBottomSheet(
+                yearRange = USER_BIRTH_RANGE,
+                reverseItemOrder = true,
                 maximumContainerHeight = 322.dp,
                 onDismissRequest = {
                     viewModel.updateBirth(it)

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -159,6 +159,7 @@ fun SignUpRoute(
                         Text(
                             modifier = Modifier
                                 .fillMaxSize()
+                                .verticalScroll(rememberScrollState())
                                 .padding(SusuTheme.spacing.spacing_m),
                             text = termState.currentTerm.description,
                             style = SusuTheme.typography.text_xxxs,

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/TermsContent.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/TermsContent.kt
@@ -79,10 +79,14 @@ fun TermListItem(
     isEssential: Boolean = true,
     canRead: Boolean = true,
     onCheckClick: (Boolean) -> Unit = {},
-    onDetailClick: () -> Unit = {},
+    onDetailClick: (() -> Unit)? = null,
 ) {
     Row(
-        modifier = modifier.padding(vertical = SusuTheme.spacing.spacing_m),
+        modifier = if (onDetailClick != null) {
+            modifier.susuClickable(onClick = onDetailClick).padding(vertical = SusuTheme.spacing.spacing_m)
+        } else {
+            modifier.padding(vertical = SusuTheme.spacing.spacing_m)
+        },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         CheckCircle(isChecked = checked, onCheckedChange = onCheckClick)
@@ -103,9 +107,7 @@ fun TermListItem(
         if (canRead) {
             Spacer(modifier = Modifier.width(SusuTheme.spacing.spacing_m))
             Image(
-                modifier = Modifier
-                    .size(20.dp)
-                    .susuClickable(rippleEnabled = false, onClick = onDetailClick),
+                modifier = Modifier.size(20.dp),
                 painter = painterResource(id = R.drawable.ic_arrow_right),
                 contentDescription = "약관 보기",
             )

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoScreen.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoScreen.kt
@@ -194,7 +194,7 @@ fun MyPageInfoScreen(
                             onClick = onBirthClick,
                         ),
                         text = if (uiState.editBirth in USER_BIRTH_RANGE) {
-                            uiState.editBirth.toString()
+                            stringResource(id = com.susu.core.designsystem.R.string.word_year_format, uiState.editBirth)
                         } else {
                             stringResource(id = com.susu.core.ui.R.string.word_not_select)
                         },
@@ -204,7 +204,7 @@ fun MyPageInfoScreen(
                 } else {
                     Text(
                         text = if (uiState.userBirth in USER_BIRTH_RANGE) {
-                            uiState.userBirth.toString()
+                            stringResource(id = com.susu.core.designsystem.R.string.word_year_format, uiState.userBirth)
                         } else {
                             stringResource(id = com.susu.core.ui.R.string.word_not_select)
                         },
@@ -263,6 +263,7 @@ fun MyPageInfoScreen(
             SusuYearPickerBottomSheet(
                 maximumContainerHeight = 322.dp,
                 yearRange = USER_BIRTH_RANGE,
+                reverseItemOrder = true,
                 onDismissRequest = { onBirthSelect(it) },
             )
         }

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoScreen.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoScreen.kt
@@ -262,6 +262,7 @@ fun MyPageInfoScreen(
         if (uiState.showDatePicker) {
             SusuYearPickerBottomSheet(
                 maximumContainerHeight = 322.dp,
+                yearRange = USER_BIRTH_RANGE,
                 onDismissRequest = { onBirthSelect(it) },
             )
         }


### PR DESCRIPTION

## 🌱 Key changes
- 회원가입
    - 약관 상세보기 터치 범위를 우측 화살표가 아닌 Row로 확대
    - 모두 동의 항목 ripple 제거
    - 약관 상세보기 스크롤 추가
    - 출생년도에 미래 년도가 등장하지 않도록 수정
    - 출생년도 바텀시트의 항목 순서를 반대로 표시
- 마이페이지
    - 출생년도 끝에 누락된 '년' 텍스트 추가 
    - 출생년도에 미래 년도가 등장하지 않도록 수정
    - 출생년도 바텀시트의 항목 순서를 반대로 표시


## 📸 스크린샷

https://github.com/YAPP-Github/oksusu-susu-android/assets/69582122/5481a9c2-02ed-41ed-ba38-ac4b20922269


