### PR TITLE
Qa/20 29 31 39 통계 관련 수정사항 

### DIFF
--- a/data/src/main/java/com/susu/data/data/repository/StatisticsRepositoryImpl.kt
+++ b/data/src/main/java/com/susu/data/data/repository/StatisticsRepositoryImpl.kt
@@ -14,7 +14,12 @@ class StatisticsRepositoryImpl @Inject constructor(
     override suspend fun getMyStatistics(): MyStatistics {
         val originalStatistic = statisticsService.getMyStatistics().getOrThrow().toModel()
         val sortedRecentSpent = originalStatistic.recentSpent.sortedBy { it.title.toInt() }
-            .map { StatisticsElement(title = it.title.substring(it.title.length - 2).toInt().toString(), value = it.value) }
+            .map {
+                StatisticsElement(
+                    title = it.title.substring(it.title.length - 2).toInt().toString(),
+                    value = it.value / 10000,
+                )
+            }
 
         return MyStatistics(
             highestAmountReceived = originalStatistic.highestAmountReceived,
@@ -23,8 +28,8 @@ class StatisticsRepositoryImpl @Inject constructor(
             mostRelationship = originalStatistic.mostRelationship,
             mostSpentMonth = originalStatistic.mostSpentMonth % 100,
             recentSpent = sortedRecentSpent,
-            recentTotalSpent = originalStatistic.recentTotalSpent,
-            recentMaximumSpent = originalStatistic.recentMaximumSpent,
+            recentTotalSpent = sortedRecentSpent.sumOf { it.value },
+            recentMaximumSpent = sortedRecentSpent.maxOfOrNull { it.value } ?: 0,
         )
     }
 
@@ -35,7 +40,12 @@ class StatisticsRepositoryImpl @Inject constructor(
             categoryId = categoryId,
         ).getOrThrow().toModel()
         val sortedRecentSpent = originalStatistic.recentSpent.sortedBy { it.title.toInt() }
-            .map { StatisticsElement(title = it.title.substring(it.title.length - 2).toInt().toString(), value = it.value) }
+            .map {
+                StatisticsElement(
+                    title = it.title.substring(it.title.length - 2).toInt().toString(),
+                    value = it.value / 10000,
+                )
+            }
 
         return SusuStatistics(
             averageSent = originalStatistic.averageSent,
@@ -45,8 +55,8 @@ class StatisticsRepositoryImpl @Inject constructor(
             mostSpentMonth = originalStatistic.mostSpentMonth % 100,
             mostRelationship = originalStatistic.mostRelationship,
             mostCategory = originalStatistic.mostCategory,
-            recentTotalSpent = originalStatistic.recentTotalSpent,
-            recentMaximumSpent = originalStatistic.recentMaximumSpent,
+            recentTotalSpent = sortedRecentSpent.sumOf { it.value },
+            recentMaximumSpent = sortedRecentSpent.maxOfOrNull { it.value } ?: 0,
         )
     }
 }

--- a/data/src/main/java/com/susu/data/data/repository/StatisticsRepositoryImpl.kt
+++ b/data/src/main/java/com/susu/data/data/repository/StatisticsRepositoryImpl.kt
@@ -13,13 +13,17 @@ class StatisticsRepositoryImpl @Inject constructor(
 ) : StatisticsRepository {
     override suspend fun getMyStatistics(): MyStatistics {
         val originalStatistic = statisticsService.getMyStatistics().getOrThrow().toModel()
-        val sortedRecentSpent = originalStatistic.recentSpent.sortedBy { it.title.toInt() }
+        val sortedRecentSpent = originalStatistic.recentSpent
+            .filter {
+                currentYear == it.title.substring(0 until 4).toInt()
+            }
             .map {
                 StatisticsElement(
                     title = it.title.substring(it.title.length - 2).toInt().toString(),
                     value = it.value / 10000,
                 )
             }
+            .sortedBy { it.title.toInt() }
 
         return MyStatistics(
             highestAmountReceived = originalStatistic.highestAmountReceived,
@@ -39,13 +43,17 @@ class StatisticsRepositoryImpl @Inject constructor(
             relationshipId = relationshipId,
             categoryId = categoryId,
         ).getOrThrow().toModel()
-        val sortedRecentSpent = originalStatistic.recentSpent.sortedBy { it.title.toInt() }
+        val sortedRecentSpent = originalStatistic.recentSpent
+            .filter {
+                currentYear == it.title.substring(0 until 4).toInt()
+            }
             .map {
                 StatisticsElement(
                     title = it.title.substring(it.title.length - 2).toInt().toString(),
                     value = it.value / 10000,
                 )
             }
+            .sortedBy { it.title.toInt() }
 
         return SusuStatistics(
             averageSent = originalStatistic.averageSent,
@@ -58,5 +66,9 @@ class StatisticsRepositoryImpl @Inject constructor(
             recentTotalSpent = sortedRecentSpent.sumOf { it.value },
             recentMaximumSpent = sortedRecentSpent.maxOfOrNull { it.value } ?: 0,
         )
+    }
+
+    companion object {
+        private val currentYear = java.time.LocalDate.now().year
     }
 }

--- a/feature/statistics/src/main/java/com/susu/feature/statistics/component/RecentSpentGraph.kt
+++ b/feature/statistics/src/main/java/com/susu/feature/statistics/component/RecentSpentGraph.kt
@@ -86,12 +86,11 @@ fun RecentSpentGraph(
                     number = totalAmount,
                     style = SusuTheme.typography.title_xs,
                     color = Blue60,
-                    prefix = stringResource(id = R.string.statistics_total_man_prefix),
                     postfix = stringResource(id = R.string.statistics_total_man_postfix),
                 )
             } else {
                 Text(
-                    text = stringResource(R.string.statistics_total_man_format, stringResource(R.string.word_unknown)),
+                    text = stringResource(R.string.statistics_man_format, stringResource(R.string.word_unknown)),
                     style = SusuTheme.typography.title_xs,
                     color = Gray40,
                 )

--- a/feature/statistics/src/main/java/com/susu/feature/statistics/content/my/MyStatisticsContent.kt
+++ b/feature/statistics/src/main/java/com/susu/feature/statistics/content/my/MyStatisticsContent.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -133,6 +134,7 @@ fun MyStatisticsContent(
                 money = uiState.statistics.highestAmountSent.value,
                 isActive = !isBlind,
             )
+            Spacer(modifier = Modifier.height(SusuTheme.spacing.spacing_xxxl))
         }
 
         if (uiState.isLoading) {

--- a/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsContent.kt
+++ b/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsContent.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -184,6 +185,7 @@ fun SusuStatisticsScreen(
                     isActive = !isBlind,
                 )
             }
+            Spacer(modifier = Modifier.height(SusuTheme.spacing.spacing_xxxl))
         }
 
         if (uiState.isAgeSheetOpen) {

--- a/feature/statistics/src/main/res/values/strings.xml
+++ b/feature/statistics/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="statistics_recent_8_total_money">최근 8개월 간 쓴 금액</string>
-    <string name="statistics_total_man_format">총 %s만원</string>
+    <string name="statistics_man_format">%s만원</string>
     <string name="statistics_total_man_prefix">총 </string>
     <string name="statistics_total_man_postfix">만원</string>
     <string name="statistics_tab_my">나의 수수</string>


### PR DESCRIPTION

## 🌱 Key changes
- 통계 관련 QA 반영했습니다.
- [최근 8개월 쓴 내역], [올해 쓴 금액] (그래프로 나오는 데이터)
    - api 단위 변경 대응하여 N만원 단위로 가공
    - 올해 데이터가 아닌 것은 보여지지 않음
    - '총' 워딩 제거
- 하단 여백 추가


## 📸 스크린샷


https://github.com/YAPP-Github/oksusu-susu-android/assets/69582122/2f456c3a-9d15-4f26-bc47-e18ebe59fbe4


