### PR TITLE
Qa/22 당겨서 새로 고침

### DIFF
--- a/feature/community/src/main/java/com/susu/feature/community/community/CommunityScreen.kt
+++ b/feature/community/src/main/java/com/susu/feature/community/community/CommunityScreen.kt
@@ -89,7 +89,7 @@ fun CommunityRoute(
     val context = LocalContext.current
 
     val refreshState = rememberPullToRefreshState(
-        positionalThreshold = 100.dp
+        positionalThreshold = 100.dp,
     )
 
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->

--- a/feature/community/src/main/java/com/susu/feature/community/community/CommunityScreen.kt
+++ b/feature/community/src/main/java/com/susu/feature/community/community/CommunityScreen.kt
@@ -18,9 +18,13 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
+import androidx.compose.material3.pulltorefresh.PullToRefreshState
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -30,6 +34,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -64,6 +69,7 @@ import com.susu.feature.community.community.component.VoteCard
 import kotlinx.coroutines.delay
 import java.time.LocalDateTime
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CommunityRoute(
     padding: PaddingValues,
@@ -81,6 +87,11 @@ fun CommunityRoute(
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val context = LocalContext.current
+
+    val refreshState = rememberPullToRefreshState(
+        positionalThreshold = 100.dp
+    )
+
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             is CommunitySideEffect.HandleException -> handleException(sideEffect.throwable, sideEffect.retry)
@@ -116,6 +127,14 @@ fun CommunityRoute(
 
     val voteListState = rememberLazyListState()
 
+    LaunchedEffect(key1 = refreshState.isRefreshing) {
+        if (refreshState.isRefreshing.not()) return@LaunchedEffect
+
+        viewModel.refreshData {
+            refreshState.endRefresh()
+        }
+    }
+
     LaunchedEffect(key1 = Unit) {
         viewModel.initData()
         viewModel.getCategoryConfig()
@@ -132,6 +151,7 @@ fun CommunityRoute(
 
     CommunityScreen(
         padding = padding,
+        refreshState = refreshState,
         uiState = uiState,
         currentTime = currentTime,
         voteListState = voteListState,
@@ -145,11 +165,12 @@ fun CommunityRoute(
     )
 }
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun CommunityScreen(
     padding: PaddingValues,
     uiState: CommunityState = CommunityState(),
+    refreshState: PullToRefreshState = rememberPullToRefreshState(),
     currentTime: LocalDateTime = LocalDateTime.now(),
     voteListState: LazyListState = rememberLazyListState(),
     onClickSearchIcon: () -> Unit = {},
@@ -163,7 +184,8 @@ fun CommunityScreen(
     Box(
         modifier = Modifier
             .padding(padding)
-            .fillMaxSize(),
+            .fillMaxSize()
+            .nestedScroll(refreshState.nestedScrollConnection),
     ) {
         Column(
             modifier = Modifier
@@ -340,6 +362,12 @@ fun CommunityScreen(
             }
         }
 
+        PullToRefreshContainer(
+            modifier = Modifier.align(Alignment.TopCenter),
+            state = refreshState,
+            containerColor = Gray10,
+        )
+
         SusuFloatingButton(
             modifier = Modifier
                 .align(Alignment.BottomEnd)
@@ -350,6 +378,7 @@ fun CommunityScreen(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Preview
 @Composable
 fun CommunityScreenPreview() {

--- a/feature/community/src/main/java/com/susu/feature/community/community/CommunityViewModel.kt
+++ b/feature/community/src/main/java/com/susu/feature/community/community/CommunityViewModel.kt
@@ -15,6 +15,7 @@ import com.susu.domain.usecase.vote.GetVoteListUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -164,6 +165,11 @@ class CommunityViewModel @Inject constructor(
             .onFailure {
                 postSideEffect(CommunitySideEffect.HandleException(it, ::getPopularVoteList))
             }
+    }
+
+    fun refreshData(onFinish: () -> Unit = {}) = viewModelScope.launch {
+        joinAll(getVoteList(true), getPopularVoteList())
+        onFinish()
     }
 
     fun selectCategory(category: Category?) {

--- a/feature/community/src/main/java/com/susu/feature/community/votedetail/VoteDetailScreen.kt
+++ b/feature/community/src/main/java/com/susu/feature/community/votedetail/VoteDetailScreen.kt
@@ -325,7 +325,6 @@ fun VoteDetailScreen(
         )
     }
 
-
     if (uiState.isLoading) {
         LoadingScreen()
     }

--- a/feature/community/src/main/java/com/susu/feature/community/votedetail/VoteDetailScreen.kt
+++ b/feature/community/src/main/java/com/susu/feature/community/votedetail/VoteDetailScreen.kt
@@ -15,8 +15,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
+import androidx.compose.material3.pulltorefresh.PullToRefreshState
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -26,6 +30,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -41,6 +46,7 @@ import com.susu.core.designsystem.component.badge.BadgeColor
 import com.susu.core.designsystem.component.badge.BadgeStyle
 import com.susu.core.designsystem.component.badge.SusuBadge
 import com.susu.core.designsystem.component.screen.LoadingScreen
+import com.susu.core.designsystem.theme.Gray10
 import com.susu.core.designsystem.theme.Gray15
 import com.susu.core.designsystem.theme.Gray50
 import com.susu.core.designsystem.theme.Orange60
@@ -58,6 +64,7 @@ import kotlinx.datetime.toJavaLocalDateTime
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun VoteDetailRoute(
     viewModel: VoteDetailViewModel = hiltViewModel(),
@@ -71,6 +78,9 @@ fun VoteDetailRoute(
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val context = LocalContext.current
+    val refreshState = rememberPullToRefreshState(
+        positionalThreshold = 100.dp,
+    )
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             is VoteDetailSideEffect.HandleException -> handleException(sideEffect.throwable, sideEffect.retry)
@@ -129,12 +139,21 @@ fun VoteDetailRoute(
         viewModel.getVoteDetail()
     }
 
+    LaunchedEffect(key1 = refreshState.isRefreshing) {
+        if (refreshState.isRefreshing.not()) return@LaunchedEffect
+
+        viewModel.getVoteDetail {
+            refreshState.endRefresh()
+        }
+    }
+
     BackHandler {
         viewModel.popBackStack()
     }
 
     VoteDetailScreen(
         uiState = uiState,
+        refreshState = refreshState,
         currentTime = currentTime,
         onClickBack = viewModel::popBackStack,
         onClickEdit = viewModel::navigateVoteEdit,
@@ -144,9 +163,11 @@ fun VoteDetailRoute(
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun VoteDetailScreen(
     uiState: VoteDetailState = VoteDetailState(),
+    refreshState: PullToRefreshState = rememberPullToRefreshState(),
     currentTime: LocalDateTime = LocalDateTime.now(),
     onClickBack: () -> Unit = {},
     onClickReport: () -> Unit = {},
@@ -154,149 +175,163 @@ fun VoteDetailScreen(
     onClickDelete: () -> Unit = {},
     onClickOption: (Long, Boolean) -> Unit = { _, _ -> },
 ) {
-    Column(
+    Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(SusuTheme.colorScheme.background10),
+            .background(SusuTheme.colorScheme.background10)
+            .nestedScroll(refreshState.nestedScrollConnection),
     ) {
-        SusuDefaultAppBar(
-            leftIcon = {
-                BackIcon(
-                    onClick = onClickBack,
-                )
-            },
-            title = uiState.vote.boardName,
-            actions = {
-                if (uiState.vote.isMine) {
-                    EditText(
-                        onClick = onClickEdit,
-                    )
-                    Spacer(modifier = Modifier.size(SusuTheme.spacing.spacing_m))
-                    DeleteText(
-                        onClick = onClickDelete,
-                    )
-                } else {
-                    Image(
-                        modifier = Modifier
-                            .size(24.dp)
-                            .susuClickable(rippleEnabled = false, onClick = onClickReport),
-                        painter = painterResource(id = R.drawable.ic_report),
-                        contentDescription = stringResource(id = com.susu.core.ui.R.string.content_description_report_button),
-                    )
-                }
-                Spacer(modifier = Modifier.size(SusuTheme.spacing.spacing_m))
-            },
-        )
-
         Column(
             modifier = Modifier
-                .padding(SusuTheme.spacing.spacing_m)
-                .weight(1f)
-                .verticalScroll(rememberScrollState()),
+                .fillMaxSize(),
         ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(SusuTheme.spacing.spacing_xxs),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                // border를 사용하지 않은 이유 see -> https://stackoverflow.com/questions/75964726/jetpack-compose-circle-shape-border-not-being-applied-as-expected
-                Box {
-                    Box(
-                        modifier = Modifier
-                            .size(20.dp)
-                            .clip(CircleShape)
-                            .background(Gray15),
+            SusuDefaultAppBar(
+                leftIcon = {
+                    BackIcon(
+                        onClick = onClickBack,
                     )
-                    Image(
-                        modifier = Modifier
-                            .size(18.dp)
-                            .clip(CircleShape)
-                            .align(Alignment.Center),
-                        painter = painterResource(id = com.susu.core.ui.R.drawable.img_default_profile),
-                        contentDescription = null,
-                    )
-                }
-
-                Text(text = stringResource(R.string.word_anonymous_susu), style = SusuTheme.typography.title_xxxs)
-
-                if (uiState.vote.isMine) {
-                    SusuBadge(
-                        color = BadgeColor.Gray20,
-                        text = stringResource(R.string.word_me),
-                        padding = BadgeStyle.extraSmallBadge,
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.size(SusuTheme.spacing.spacing_m))
-
-            Text(
-                modifier = Modifier.fillMaxWidth(),
-                text = uiState.vote.content,
-                style = SusuTheme.typography.text_xxs,
+                },
+                title = uiState.vote.boardName,
+                actions = {
+                    if (uiState.vote.isMine) {
+                        EditText(
+                            onClick = onClickEdit,
+                        )
+                        Spacer(modifier = Modifier.size(SusuTheme.spacing.spacing_m))
+                        DeleteText(
+                            onClick = onClickDelete,
+                        )
+                    } else {
+                        Image(
+                            modifier = Modifier
+                                .size(24.dp)
+                                .susuClickable(rippleEnabled = false, onClick = onClickReport),
+                            painter = painterResource(id = R.drawable.ic_report),
+                            contentDescription = stringResource(id = com.susu.core.ui.R.string.content_description_report_button),
+                        )
+                    }
+                    Spacer(modifier = Modifier.size(SusuTheme.spacing.spacing_m))
+                },
             )
 
-            Spacer(modifier = Modifier.size(SusuTheme.spacing.spacing_xl))
-
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
+            Column(
+                modifier = Modifier
+                    .padding(SusuTheme.spacing.spacing_m)
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState()),
             ) {
-                Icon(
-                    modifier = Modifier.size(20.dp),
-                    painter = painterResource(id = R.drawable.ic_vote),
-                    contentDescription = null,
-                    tint = Orange60,
-                )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(SusuTheme.spacing.spacing_xxs),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    // border를 사용하지 않은 이유 see -> https://stackoverflow.com/questions/75964726/jetpack-compose-circle-shape-border-not-being-applied-as-expected
+                    Box {
+                        Box(
+                            modifier = Modifier
+                                .size(20.dp)
+                                .clip(CircleShape)
+                                .background(Gray15),
+                        )
+                        Image(
+                            modifier = Modifier
+                                .size(18.dp)
+                                .clip(CircleShape)
+                                .align(Alignment.Center),
+                            painter = painterResource(id = com.susu.core.ui.R.drawable.img_default_profile),
+                            contentDescription = null,
+                        )
+                    }
 
-                Spacer(modifier = Modifier.size(SusuTheme.spacing.spacing_xxxxs))
+                    Text(text = stringResource(R.string.word_anonymous_susu), style = SusuTheme.typography.title_xxxs)
 
-                Text(
-                    text = stringResource(R.string.vote_card_count, uiState.vote.count),
-                    style = SusuTheme.typography.title_xxxs,
-                    color = Orange60,
-                )
-
-                Spacer(modifier = Modifier.weight(1f))
-
-                val totalMinutes = ChronoUnit.MINUTES.between(uiState.vote.createdAt.toJavaLocalDateTime(), currentTime)
-
-                val writeTime = when {
-                    totalMinutes / 60 > 24 -> uiState.vote.createdAt.toJavaLocalDateTime().to_yyyy_dot_MM_dot_dd()
-                    totalMinutes / 60 > 0 -> stringResource(R.string.word_before_hour, totalMinutes / 60)
-                    totalMinutes / 60 == 0L -> stringResource(R.string.word_before_minute, totalMinutes % 60 + 1)
-                    else -> uiState.vote.createdAt.toJavaLocalDateTime().to_yyyy_dot_MM_dot_dd()
+                    if (uiState.vote.isMine) {
+                        SusuBadge(
+                            color = BadgeColor.Gray20,
+                            text = stringResource(R.string.word_me),
+                            padding = BadgeStyle.extraSmallBadge,
+                        )
+                    }
                 }
 
+                Spacer(modifier = Modifier.size(SusuTheme.spacing.spacing_m))
+
                 Text(
-                    text = writeTime,
-                    style = SusuTheme.typography.text_xxxs,
-                    color = Gray50,
+                    modifier = Modifier.fillMaxWidth(),
+                    text = uiState.vote.content,
+                    style = SusuTheme.typography.text_xxs,
                 )
-            }
 
-            Spacer(modifier = Modifier.size(SusuTheme.spacing.spacing_m))
+                Spacer(modifier = Modifier.size(SusuTheme.spacing.spacing_xl))
 
-            Column(
-                verticalArrangement = Arrangement.spacedBy(SusuTheme.spacing.spacing_xxs),
-            ) {
-                uiState.vote.optionList.forEach {
-                    VoteItem(
-                        title = it.content,
-                        isPick = it.isVoted,
-                        voteCount = it.count,
-                        totalVoteCount = uiState.vote.count,
-                        showResult = uiState.vote.optionList.any { it.isVoted },
-                        onClick = { onClickOption(it.id, it.isVoted) },
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        modifier = Modifier.size(20.dp),
+                        painter = painterResource(id = R.drawable.ic_vote),
+                        contentDescription = null,
+                        tint = Orange60,
                     )
+
+                    Spacer(modifier = Modifier.size(SusuTheme.spacing.spacing_xxxxs))
+
+                    Text(
+                        text = stringResource(R.string.vote_card_count, uiState.vote.count),
+                        style = SusuTheme.typography.title_xxxs,
+                        color = Orange60,
+                    )
+
+                    Spacer(modifier = Modifier.weight(1f))
+
+                    val totalMinutes = ChronoUnit.MINUTES.between(uiState.vote.createdAt.toJavaLocalDateTime(), currentTime)
+
+                    val writeTime = when {
+                        totalMinutes / 60 > 24 -> uiState.vote.createdAt.toJavaLocalDateTime().to_yyyy_dot_MM_dot_dd()
+                        totalMinutes / 60 > 0 -> stringResource(R.string.word_before_hour, totalMinutes / 60)
+                        totalMinutes / 60 == 0L -> stringResource(R.string.word_before_minute, totalMinutes % 60 + 1)
+                        else -> uiState.vote.createdAt.toJavaLocalDateTime().to_yyyy_dot_MM_dot_dd()
+                    }
+
+                    Text(
+                        text = writeTime,
+                        style = SusuTheme.typography.text_xxxs,
+                        color = Gray50,
+                    )
+                }
+
+                Spacer(modifier = Modifier.size(SusuTheme.spacing.spacing_m))
+
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(SusuTheme.spacing.spacing_xxs),
+                ) {
+                    uiState.vote.optionList.forEach {
+                        VoteItem(
+                            title = it.content,
+                            isPick = it.isVoted,
+                            voteCount = it.count,
+                            totalVoteCount = uiState.vote.count,
+                            showResult = uiState.vote.optionList.any { it.isVoted },
+                            onClick = { onClickOption(it.id, it.isVoted) },
+                        )
+                    }
                 }
             }
         }
+
+        PullToRefreshContainer(
+            modifier = Modifier.align(Alignment.TopCenter),
+            state = refreshState,
+            containerColor = Gray10,
+        )
     }
+
 
     if (uiState.isLoading) {
         LoadingScreen()
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Preview
 @Composable
 fun VoteDetailScreenPreview() {

--- a/feature/community/src/main/java/com/susu/feature/community/votedetail/VoteDetailViewModel.kt
+++ b/feature/community/src/main/java/com/susu/feature/community/votedetail/VoteDetailViewModel.kt
@@ -35,8 +35,8 @@ class VoteDetailViewModel @Inject constructor(
     private var initCount: Long = 0
     private var initIsVoted: Boolean = false
 
-    fun getVoteDetail() = viewModelScope.launch {
-        intent { copy(isLoading = true) }
+    fun getVoteDetail(onFinish: (() -> Unit)? = null) = viewModelScope.launch {
+        intent { copy(isLoading = onFinish == null) }
         getVoteDetailUseCase(
             voteId,
         ).onSuccess {
@@ -48,6 +48,7 @@ class VoteDetailViewModel @Inject constructor(
             postSideEffect(VoteDetailSideEffect.HandleException(it, ::getVoteDetail))
         }
         intent { copy(isLoading = false) }
+        onFinish?.invoke()
     }
 
     fun vote(optionId: Long, isVoted: Boolean) {

--- a/feature/received/src/main/java/com/susu/feature/received/ledgerdetail/LedgerDetailScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgerdetail/LedgerDetailScreen.kt
@@ -87,7 +87,7 @@ fun LedgerDetailRoute(
     val listState = rememberLazyListState()
     val context = LocalContext.current
     val refreshState = rememberPullToRefreshState(
-        positionalThreshold = 100.dp
+        positionalThreshold = 100.dp,
     )
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {

--- a/feature/received/src/main/java/com/susu/feature/received/ledgerdetail/LedgerDetailScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgerdetail/LedgerDetailScreen.kt
@@ -22,10 +22,14 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
+import androidx.compose.material3.pulltorefresh.PullToRefreshState
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -45,6 +49,7 @@ import com.susu.core.designsystem.component.button.SelectedFilterButton
 import com.susu.core.designsystem.component.button.SmallButtonStyle
 import com.susu.core.designsystem.component.button.SusuFloatingButton
 import com.susu.core.designsystem.component.button.SusuGhostButton
+import com.susu.core.designsystem.theme.Gray10
 import com.susu.core.designsystem.theme.Gray25
 import com.susu.core.designsystem.theme.Gray50
 import com.susu.core.designsystem.theme.SusuTheme
@@ -61,6 +66,7 @@ import com.susu.feature.received.ledgerdetail.component.LedgerDetailEnvelopeCont
 import com.susu.feature.received.ledgerdetail.component.LedgerDetailOverviewColumn
 import kotlinx.collections.immutable.toPersistentList
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LedgerDetailRoute(
     viewModel: LedgerDetailViewModel = hiltViewModel(),
@@ -80,6 +86,9 @@ fun LedgerDetailRoute(
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val listState = rememberLazyListState()
     val context = LocalContext.current
+    val refreshState = rememberPullToRefreshState(
+        positionalThreshold = 100.dp
+    )
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             is LedgerDetailSideEffect.NavigateLedgerEdit -> navigateLedgerEdit(sideEffect.ledger)
@@ -113,6 +122,14 @@ fun LedgerDetailRoute(
         }
     }
 
+    LaunchedEffect(key1 = refreshState.isRefreshing) {
+        if (refreshState.isRefreshing.not()) return@LaunchedEffect
+
+        viewModel.refreshData {
+            refreshState.endRefresh()
+        }
+    }
+
     LaunchedEffect(key1 = Unit) {
         viewModel.getLedger()
         viewModel.initReceivedEnvelopeList()
@@ -134,6 +151,8 @@ fun LedgerDetailRoute(
 
     LedgerDetailScreen(
         uiState = uiState,
+        listState = listState,
+        refreshState = refreshState,
         onClickEdit = viewModel::navigateLedgerEdit,
         onClickDelete = viewModel::showDeleteDialog,
         onClickBack = viewModel::popBackStackWithLedger,
@@ -154,6 +173,7 @@ fun LedgerDetailRoute(
 fun LedgerDetailScreen(
     uiState: LedgerDetailState = LedgerDetailState(),
     listState: LazyListState = rememberLazyListState(),
+    refreshState: PullToRefreshState = rememberPullToRefreshState(),
     onClickBack: () -> Unit = {},
     onClickEdit: () -> Unit = {},
     onClickDelete: () -> Unit = {},
@@ -170,7 +190,8 @@ fun LedgerDetailScreen(
     Box(
         modifier = Modifier
             .background(SusuTheme.colorScheme.background15)
-            .fillMaxSize(),
+            .fillMaxSize()
+            .nestedScroll(refreshState.nestedScrollConnection),
     ) {
         Column {
             SusuDefaultAppBar(
@@ -294,6 +315,12 @@ fun LedgerDetailScreen(
             }
         }
 
+        PullToRefreshContainer(
+            modifier = Modifier.align(Alignment.TopCenter),
+            state = refreshState,
+            containerColor = Gray10,
+        )
+
         if (uiState.showAlignBottomSheet) {
             SusuSelectionBottomSheet(
                 onDismissRequest = onDismissAlignBottomSheet,
@@ -313,6 +340,7 @@ fun LedgerDetailScreen(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Preview
 @Composable
 fun LedgerDetailScreenPreview() {

--- a/feature/received/src/main/java/com/susu/feature/received/ledgerdetail/LedgerDetailViewModel.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgerdetail/LedgerDetailViewModel.kt
@@ -18,6 +18,7 @@ import com.susu.domain.usecase.ledger.GetLedgerUseCase
 import com.susu.feature.received.navigation.ReceivedRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.datetime.toJavaLocalDateTime
 import kotlinx.serialization.json.Json
@@ -42,6 +43,11 @@ class LedgerDetailViewModel @Inject constructor(
     private var filterUri: String? = null
 
     private var isFirstVisited: Boolean = true
+
+    fun refreshData(onFinish: () -> Unit) = viewModelScope.launch {
+        joinAll(getLedger(), getReceivedEnvelopeList(true))
+        onFinish()
+    }
 
     fun filterIfNeed(filterUri: String?) {
         if (filterUri == null) return

--- a/feature/received/src/main/java/com/susu/feature/received/received/ReceivedScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/received/ReceivedScreen.kt
@@ -20,11 +20,15 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
+import androidx.compose.material3.pulltorefresh.PullToRefreshState
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -42,6 +46,7 @@ import com.susu.core.designsystem.component.button.SelectedFilterButton
 import com.susu.core.designsystem.component.button.SmallButtonStyle
 import com.susu.core.designsystem.component.button.SusuFloatingButton
 import com.susu.core.designsystem.component.button.SusuGhostButton
+import com.susu.core.designsystem.theme.Gray10
 import com.susu.core.designsystem.theme.Gray15
 import com.susu.core.designsystem.theme.Gray50
 import com.susu.core.designsystem.theme.SusuTheme
@@ -61,6 +66,7 @@ import me.onebone.toolbar.CollapsingToolbarScaffold
 import me.onebone.toolbar.ScrollStrategy
 import me.onebone.toolbar.rememberCollapsingToolbarScaffoldState
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ReceivedRoute(
     viewModel: ReceivedViewModel = hiltViewModel(),
@@ -76,6 +82,9 @@ fun ReceivedRoute(
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val ledgerListState = rememberLazyGridState()
     val scope = rememberCoroutineScope()
+    val refreshState = rememberPullToRefreshState(
+        positionalThreshold = 100.dp
+    )
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             ReceivedEffect.NavigateLedgerAdd -> navigateLedgerAdd()
@@ -86,6 +95,14 @@ fun ReceivedRoute(
                 awaitFrame()
                 ledgerListState.animateScrollToItem(0)
             }
+        }
+    }
+
+    LaunchedEffect(key1 = refreshState.isRefreshing) {
+        if (refreshState.isRefreshing.not()) return@LaunchedEffect
+
+        viewModel.getLedgerList(needClear = true) {
+            refreshState.endRefresh()
         }
     }
 
@@ -103,6 +120,7 @@ fun ReceivedRoute(
     ReceiveScreen(
         uiState = uiState,
         ledgerListState = ledgerListState,
+        refreshState = refreshState,
         padding = padding,
         onClickLedgerCard = viewModel::navigateLedgerDetail,
         onClickLedgerAddCard = viewModel::navigateLedgerAdd,
@@ -124,6 +142,7 @@ fun ReceivedRoute(
 @Composable
 fun ReceiveScreen(
     uiState: ReceivedState = ReceivedState(),
+    refreshState: PullToRefreshState = rememberPullToRefreshState(),
     ledgerListState: LazyGridState = rememberLazyGridState(),
     padding: PaddingValues,
     onClickSearchIcon: () -> Unit = {},
@@ -141,7 +160,8 @@ fun ReceiveScreen(
         modifier = Modifier
             .background(SusuTheme.colorScheme.background15)
             .padding(padding)
-            .fillMaxSize(),
+            .fillMaxSize()
+            .nestedScroll(refreshState.nestedScrollConnection),
     ) {
         Column {
             Spacer(modifier = Modifier.size(44.dp))
@@ -249,6 +269,12 @@ fun ReceiveScreen(
             },
         )
 
+        PullToRefreshContainer(
+            modifier = Modifier.align(Alignment.TopCenter),
+            state = refreshState,
+            containerColor = Gray10,
+        )
+
         if (uiState.showEmptyLedger) {
             Text(
                 modifier = Modifier.align(Alignment.Center),
@@ -277,6 +303,7 @@ fun ReceiveScreen(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Preview
 @Composable
 fun ReceivedScreenPreview() {

--- a/feature/received/src/main/java/com/susu/feature/received/received/ReceivedScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/received/ReceivedScreen.kt
@@ -83,7 +83,7 @@ fun ReceivedRoute(
     val ledgerListState = rememberLazyGridState()
     val scope = rememberCoroutineScope()
     val refreshState = rememberPullToRefreshState(
-        positionalThreshold = 100.dp
+        positionalThreshold = 100.dp,
     )
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {

--- a/feature/received/src/main/java/com/susu/feature/received/received/ReceivedViewModel.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/received/ReceivedViewModel.kt
@@ -84,7 +84,7 @@ class ReceivedViewModel @Inject constructor(
         getLedgerList(true)
     }
 
-    fun getLedgerList(needClear: Boolean = false) = viewModelScope.launch {
+    fun getLedgerList(needClear: Boolean = false, onFinish: () -> Unit = {}) = viewModelScope.launch {
         mutex.withLock {
             val currentList = if (needClear) {
                 page = 0
@@ -117,6 +117,7 @@ class ReceivedViewModel @Inject constructor(
             }
 
             if (needClear) postSideEffect(ReceivedEffect.ScrollToTop)
+            onFinish()
         }
     }
 

--- a/feature/sent/src/main/java/com/susu/feature/envelope/SentEnvelopeScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelope/SentEnvelopeScreen.kt
@@ -16,13 +16,19 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
+import androidx.compose.material3.pulltorefresh.PullToRefreshState
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -33,6 +39,7 @@ import com.susu.core.designsystem.component.appbar.icon.BackIcon
 import com.susu.core.designsystem.component.badge.BadgeColor
 import com.susu.core.designsystem.component.badge.BadgeStyle
 import com.susu.core.designsystem.component.badge.SusuBadge
+import com.susu.core.designsystem.theme.Gray10
 import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.Gray20
 import com.susu.core.designsystem.theme.Gray60
@@ -46,6 +53,7 @@ import com.susu.feature.envelope.component.EnvelopeHistoryItem
 import com.susu.feature.sent.R
 import kotlinx.datetime.toJavaLocalDateTime
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SentEnvelopeRoute(
     viewModel: SentEnvelopeViewModel = hiltViewModel(),
@@ -57,6 +65,10 @@ fun SentEnvelopeRoute(
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val historyListState = rememberLazyListState()
+
+    val refreshState = rememberPullToRefreshState(
+        positionalThreshold = 100.dp
+    )
 
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
@@ -77,20 +89,31 @@ fun SentEnvelopeRoute(
         viewModel.getEnvelopeHistoryList()
     }
 
+    LaunchedEffect(key1 = refreshState.isRefreshing) {
+        if (refreshState.isRefreshing.not()) return@LaunchedEffect
+
+        viewModel.initData {
+            refreshState.endRefresh()
+        }
+    }
+
     BackHandler {
         editedFriendId?.let { popBackStackWithEditedFriendId(it) } ?: popBackStack()
     }
 
     SentEnvelopeScreen(
         uiState = uiState,
+        refreshState = refreshState,
         onClickBackIcon = viewModel::popBackStack,
         onClickEnvelopeDetail = viewModel::navigateSentEnvelopeDetail,
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SentEnvelopeScreen(
     modifier: Modifier = Modifier,
+    refreshState: PullToRefreshState = rememberPullToRefreshState(),
     uiState: SentEnvelopeState = SentEnvelopeState(),
     historyListState: LazyListState = rememberLazyListState(),
     onClickBackIcon: () -> Unit = {},
@@ -99,7 +122,8 @@ fun SentEnvelopeScreen(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(SusuTheme.colorScheme.background10),
+            .background(SusuTheme.colorScheme.background10)
+            .nestedScroll(refreshState.nestedScrollConnection),
     ) {
         Column {
             SusuDefaultAppBar(
@@ -194,9 +218,16 @@ fun SentEnvelopeScreen(
                 }
             }
         }
+
+        PullToRefreshContainer(
+            modifier = Modifier.align(Alignment.TopCenter),
+            state = refreshState,
+            containerColor = Gray10,
+        )
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Preview
 @Composable
 fun SentEnvelopeScreenPreview() {

--- a/feature/sent/src/main/java/com/susu/feature/envelope/SentEnvelopeScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelope/SentEnvelopeScreen.kt
@@ -67,7 +67,7 @@ fun SentEnvelopeRoute(
     val historyListState = rememberLazyListState()
 
     val refreshState = rememberPullToRefreshState(
-        positionalThreshold = 100.dp
+        positionalThreshold = 100.dp,
     )
 
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->

--- a/feature/sent/src/main/java/com/susu/feature/envelope/SentEnvelopeViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelope/SentEnvelopeViewModel.kt
@@ -21,9 +21,10 @@ class SentEnvelopeViewModel @Inject constructor(
 ) {
     private val friendId = savedStateHandle.get<Long>(SentRoute.FRIEND_ID_ARGUMENT_NAME)!!
 
-    fun initData() {
+    fun initData(onFinish: () -> Unit = {}) {
         getEnvelopeInfo()
         getEnvelopeHistoryList()
+        onFinish()
     }
 
     private fun getEnvelopeInfo(id: Long = friendId) = viewModelScope.launch {

--- a/feature/sent/src/main/java/com/susu/feature/sent/SentScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/SentScreen.kt
@@ -81,7 +81,7 @@ fun SentRoute(
     val scope = rememberCoroutineScope()
 
     val refreshState = rememberPullToRefreshState(
-        positionalThreshold = 100.dp
+        positionalThreshold = 100.dp,
     )
 
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->

--- a/feature/sent/src/main/java/com/susu/feature/sent/SentScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/SentScreen.kt
@@ -20,11 +20,15 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
+import androidx.compose.material3.pulltorefresh.PullToRefreshState
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -42,6 +46,7 @@ import com.susu.core.designsystem.component.button.SelectedFilterButton
 import com.susu.core.designsystem.component.button.SmallButtonStyle
 import com.susu.core.designsystem.component.button.SusuFloatingButton
 import com.susu.core.designsystem.component.button.SusuGhostButton
+import com.susu.core.designsystem.theme.Gray10
 import com.susu.core.designsystem.theme.Gray15
 import com.susu.core.designsystem.theme.Gray50
 import com.susu.core.designsystem.theme.SusuTheme
@@ -57,6 +62,7 @@ import me.onebone.toolbar.CollapsingToolbarScaffold
 import me.onebone.toolbar.ScrollStrategy
 import me.onebone.toolbar.rememberCollapsingToolbarScaffoldState
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SentRoute(
     viewModel: SentViewModel = hiltViewModel(),
@@ -74,6 +80,10 @@ fun SentRoute(
     val envelopesListState = rememberLazyListState()
     val scope = rememberCoroutineScope()
 
+    val refreshState = rememberPullToRefreshState(
+        positionalThreshold = 100.dp
+    )
+
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             SentEffect.NavigateEnvelopeAdd -> navigateSentEnvelopeAdd()
@@ -84,6 +94,14 @@ fun SentRoute(
                 awaitFrame()
                 envelopesListState.animateScrollToItem(0)
             }
+        }
+    }
+
+    LaunchedEffect(key1 = refreshState.isRefreshing) {
+        if (refreshState.isRefreshing.not()) return@LaunchedEffect
+
+        viewModel.getEnvelopesList(refresh = true) {
+            refreshState.endRefresh()
         }
     }
 
@@ -105,6 +123,7 @@ fun SentRoute(
     SentScreen(
         uiState = uiState,
         envelopesListState = envelopesListState,
+        refreshState = refreshState,
         padding = padding,
         onClickHistoryShowAll = viewModel::navigateSentEnvelope,
         onClickAddEnvelope = viewModel::navigateSentAdd,
@@ -130,6 +149,7 @@ fun SentRoute(
 fun SentScreen(
     uiState: SentState = SentState(),
     envelopesListState: LazyListState = rememberLazyListState(),
+    refreshState: PullToRefreshState = rememberPullToRefreshState(),
     padding: PaddingValues,
     onClickSearchIcon: () -> Unit = {},
     onClickHistory: (Boolean, Long) -> Unit = { _, _ -> },
@@ -147,7 +167,8 @@ fun SentScreen(
             modifier = Modifier
                 .background(SusuTheme.colorScheme.background15)
                 .padding(padding)
-                .fillMaxSize(),
+                .fillMaxSize()
+                .nestedScroll(refreshState.nestedScrollConnection),
         ) {
             Column {
                 Spacer(modifier = Modifier.size(44.dp))
@@ -210,6 +231,12 @@ fun SentScreen(
                 actions = {
                     SearchIcon(onClickSearchIcon)
                 },
+            )
+
+            PullToRefreshContainer(
+                modifier = Modifier.align(Alignment.TopCenter),
+                state = refreshState,
+                containerColor = Gray10,
             )
 
             if (uiState.showAlignBottomSheet) {
@@ -314,6 +341,7 @@ fun EmptyView(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Preview
 @Composable
 fun SentScreenPreview() {

--- a/feature/sent/src/main/java/com/susu/feature/sent/SentViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/SentViewModel.kt
@@ -28,7 +28,7 @@ class SentViewModel @Inject constructor(
     private var filter: EnvelopeFilterArgument = EnvelopeFilterArgument()
     private var filterUri: String? = null
 
-    fun getEnvelopesList(refresh: Boolean?) = viewModelScope.launch {
+    fun getEnvelopesList(refresh: Boolean?, onFinish: () -> Unit = {}) = viewModelScope.launch {
         mutex.withLock {
             val currentList = if (refresh == true) {
                 page = 0
@@ -63,6 +63,8 @@ class SentViewModel @Inject constructor(
             }
 
             if (refresh == true) postSideEffect(SentEffect.ScrollToTop)
+
+            onFinish()
         }
     }
 

--- a/feature/statistics/src/main/java/com/susu/feature/statistics/content/my/MyStatisticsViewModel.kt
+++ b/feature/statistics/src/main/java/com/susu/feature/statistics/content/my/MyStatisticsViewModel.kt
@@ -11,9 +11,9 @@ import javax.inject.Inject
 class MyStatisticsViewModel @Inject constructor(
     private val getMyStatisticsUseCase: GetMyStatisticsUseCase,
 ) : BaseViewModel<MyStatisticsState, MyStatisticsEffect>(MyStatisticsState()) {
-    fun getMyStatistics() {
+    fun getMyStatistics(onFinish: (() -> Unit)? = null) {
         viewModelScope.launch {
-            intent { copy(isLoading = true) }
+            intent { copy(isLoading = onFinish == null) }
             getMyStatisticsUseCase()
                 .onSuccess {
                     intent { copy(statistics = it) }
@@ -21,6 +21,8 @@ class MyStatisticsViewModel @Inject constructor(
                     postSideEffect(MyStatisticsEffect.HandleException(it, ::getMyStatistics))
                 }
             intent { copy(isLoading = false) }
+
+            onFinish?.invoke()
         }
     }
 }

--- a/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsViewModel.kt
+++ b/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsViewModel.kt
@@ -47,7 +47,7 @@ class SusuStatisticsViewModel @Inject constructor(
         }
     }
 
-    fun getSusuStatistics() {
+    fun getSusuStatistics(onFinish: () -> Unit = {}) {
         if (currentState.relationship !in currentState.relationshipConfig &&
             currentState.category !in currentState.categoryConfig
         ) {
@@ -64,6 +64,8 @@ class SusuStatisticsViewModel @Inject constructor(
             }.onFailure {
                 postSideEffect(SusuStatisticsEffect.HandleException(it, ::getSusuStatistics))
             }
+
+            onFinish()
         }
     }
 


### PR DESCRIPTION
## 💡 Issue
- Resolved: #이슈번호

## 🌱 Key changes
<!--변경사항 적기-->
화면 별로 당겨서 새로고침 하는 기능 구현했습니다.

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|

https://github.com/YAPP-Github/oksusu-susu-android/assets/81678959/621e63f0-8346-4113-9eaf-9ea8c7d770c6

