### PR TITLE
Qa/26 51 브라우저 미설치 강제종료, 웹뷰 상단에 앱바 추가

### DIFF
--- a/feature/mypage/src/main/java/com/susu/feature/mypage/MyPagePrivacyPolicyScreen.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/MyPagePrivacyPolicyScreen.kt
@@ -2,25 +2,41 @@ package com.susu.feature.mypage
 
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
+import com.susu.core.designsystem.component.appbar.SusuDefaultAppBar
+import com.susu.core.designsystem.component.appbar.icon.BackIcon
+import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.ui.PRIVACY_POLICY_URL
 
 @Composable
 fun MyPagePrivacyPolicyScreen(
     modifier: Modifier = Modifier,
+    popBackStack: () -> Unit,
 ) {
-    AndroidView(
-        modifier = modifier.fillMaxSize(),
-        factory = { context ->
-            return@AndroidView WebView(context).apply {
-                webViewClient = WebViewClient()
-            }
-        },
-        update = {
-            it.loadUrl(PRIVACY_POLICY_URL)
-        },
-    )
+    Column(
+        modifier.fillMaxSize(),
+    ) {
+        SusuDefaultAppBar(
+            modifier = Modifier.padding(horizontal = SusuTheme.spacing.spacing_xs),
+            leftIcon = {
+                BackIcon(onClick = popBackStack)
+            },
+        )
+        AndroidView(
+            modifier = Modifier.weight(1f),
+            factory = { context ->
+                return@AndroidView WebView(context).apply {
+                    webViewClient = WebViewClient()
+                }
+            },
+            update = {
+                it.loadUrl(PRIVACY_POLICY_URL)
+            },
+        )
+    }
 }

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/main/MyPageDefaultScreen.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/main/MyPageDefaultScreen.kt
@@ -153,7 +153,11 @@ fun MyPageDefaultRoute(
         onWithdraw = viewModel::showWithdrawDialog,
         onExport = viewModel::showExportDialog,
         onClickFeedback = {
-            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(SUSU_GOOGLE_FROM_URL)))
+            runCatching {
+                context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(SUSU_GOOGLE_FROM_URL)))
+            }.onFailure {
+                onShowSnackbar(SnackbarToken(message = context.getString(com.susu.feature.mypage.R.string.snackbar_browser_not_found)))
+            }
         },
         navigateToInfo = navigateToInfo,
         navigateToSocial = navigateToSocial,

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/navigation/MyPageNavigation.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/navigation/MyPageNavigation.kt
@@ -60,10 +60,14 @@ fun NavGraphBuilder.myPageNavGraph(
         )
     }
     composable(route = MyPageRoute.socialRoute) {
-        MyPageSocialRoute(padding = padding, popBackStack = popBackStack)
+        MyPageSocialRoute(
+            padding = padding,
+            popBackStack = popBackStack,
+            onShowSnackbar = onShowSnackbar,
+        )
     }
     composable(route = MyPageRoute.privacyPolicyRoute) {
-        MyPagePrivacyPolicyScreen()
+        MyPagePrivacyPolicyScreen(popBackStack = popBackStack)
     }
 }
 

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/social/MyPageSocialScreen.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/social/MyPageSocialScreen.kt
@@ -36,6 +36,7 @@ import com.susu.core.designsystem.theme.Gray50
 import com.susu.core.designsystem.theme.Gray70
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.ui.SUSU_GOOGLE_FROM_URL
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.SnsProviders
 import com.susu.feature.mypage.R
 
@@ -43,13 +44,19 @@ import com.susu.feature.mypage.R
 fun MyPageSocialRoute(
     padding: PaddingValues,
     popBackStack: () -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
 ) {
-    MyPageSocialScreen(padding = padding, popBackStack = popBackStack)
+    MyPageSocialScreen(
+        padding = padding,
+        popBackStack = popBackStack,
+        onShowSnackbar = onShowSnackbar,
+    )
 }
 
 @Composable
 fun MyPageSocialScreen(
     padding: PaddingValues = PaddingValues(),
+    onShowSnackbar: (SnackbarToken) -> Unit = {},
     popBackStack: () -> Unit = {},
 ) {
     val context = LocalContext.current
@@ -89,7 +96,13 @@ fun MyPageSocialScreen(
             style = XSmallButtonStyle.height36,
             isActive = false,
             isClickable = true,
-            onClick = { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(SUSU_GOOGLE_FROM_URL))) },
+            onClick = {
+                runCatching {
+                    context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(SUSU_GOOGLE_FROM_URL)))
+                }.onFailure {
+                    onShowSnackbar(SnackbarToken(message = context.getString(R.string.snackbar_browser_not_found)))
+                }
+            },
         )
     }
 }

--- a/feature/mypage/src/main/res/values/strings.xml
+++ b/feature/mypage/src/main/res/values/strings.xml
@@ -29,4 +29,5 @@
     <string name="mypage_my_info_profile">프로필 이미지</string>
     <string name="mypage_my_info_snackbar_invalid_name">이름은 한글 또는 영문 10글자로 입력해주세요</string>
     <string name="mypage_default_recent_version">최신 버전 %s</string>
+    <string name="snackbar_browser_not_found">먼저 브라우저를 설치해주세요!</string>
 </resources>


### PR DESCRIPTION

## 🌱 Key changes
- 개인정보 처리방침 상단에 `SusuDefaultAppBar`를 추가하여 뒤로가기를 추가했습니다.
- 브라우저 미 설치 기기에서 수수 구글 폼 웹페이지를 열 때 강제종료 되는 문제를 고쳤습니다.
    - 이제는 강제종료 대신 아래와 같은 스낵바가 노출됩니다.  

## 📸 스크린샷

<img width="313" alt="스크린샷 2024-02-13 오후 12 17 09" src="https://github.com/YAPP-Github/oksusu-susu-android/assets/69582122/c2959266-8039-4216-afcb-46c92c3cfd11">
- 브라우저 미 설치 애뮬레이터에서 '문의하기'를 누른 모습