### PR TITLE
Qa/48 카카오톡, 브라우저 모두 미 설치 케이스 대응

### DIFF
--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/login/LoginContract.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/login/LoginContract.kt
@@ -3,14 +3,12 @@ package com.susu.feature.loginsignup.login
 import com.susu.core.ui.base.SideEffect
 import com.susu.core.ui.base.UiState
 
-sealed interface LoginContract {
-    sealed class LoginEffect : SideEffect {
-        data object NavigateToReceived : LoginEffect()
-        data object NavigateToSignUp : LoginEffect()
-        data class ShowToast(val msg: String) : LoginEffect()
-    }
-
-    data class LoginState(
-        val isLoading: Boolean = false,
-    ) : UiState
+sealed interface LoginEffect : SideEffect {
+    data object NavigateToReceived : LoginEffect
+    data object NavigateToSignUp : LoginEffect
+    data class ShowSnackBar(val message: String) : LoginEffect
 }
+
+data class LoginState(
+    val isLoading: Boolean = false,
+) : UiState

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/login/LoginViewModel.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/login/LoginViewModel.kt
@@ -1,6 +1,7 @@
 package com.susu.feature.loginsignup.login
 
 import androidx.lifecycle.viewModelScope
+import com.susu.core.model.exception.UnknownException
 import com.susu.core.ui.SnsProviders
 import com.susu.core.ui.base.BaseViewModel
 import com.susu.domain.usecase.loginsignup.CheckCanRegisterUseCase
@@ -13,30 +14,31 @@ import javax.inject.Inject
 class LoginViewModel @Inject constructor(
     private val checkCanRegisterUseCase: CheckCanRegisterUseCase,
     private val loginUseCase: LoginUseCase,
-) : BaseViewModel<LoginContract.LoginState, LoginContract.LoginEffect>(LoginContract.LoginState()) {
+) : BaseViewModel<LoginState, LoginEffect>(LoginState()) {
 
     fun login(provider: SnsProviders, oauthAccessToken: String) {
         viewModelScope.launch {
             intent { copy(isLoading = true) }
             // 수수 서버에 가입되지 않은 회원이라면 -> 회원 정보 기입 후 수수 회원가입
-            checkCanRegisterUseCase(provider = provider.path, oauthAccessToken = oauthAccessToken).onSuccess { canRegister ->
-                if (canRegister) {
-                    postSideEffect(LoginContract.LoginEffect.NavigateToSignUp)
-                } else {
-                    loginUseCase(provider = provider.path, oauthAccessToken = oauthAccessToken)
-                        .onSuccess {
-                            postSideEffect(LoginContract.LoginEffect.NavigateToReceived)
-                        }
-                        .onFailure {
-                            postSideEffect(LoginContract.LoginEffect.ShowToast(it.message ?: "수수 로그인에 실패했어요"))
-                        }
+            checkCanRegisterUseCase(provider = provider.path, oauthAccessToken = oauthAccessToken)
+                .onSuccess { canRegister ->
+                    if (canRegister) {
+                        postSideEffect(LoginEffect.NavigateToSignUp)
+                    } else {
+                        loginUseCase(provider = provider.path, oauthAccessToken = oauthAccessToken)
+                            .onSuccess {
+                                postSideEffect(LoginEffect.NavigateToReceived)
+                            }
+                            .onFailure {
+                                postSideEffect(LoginEffect.ShowSnackBar(message = it.message ?: UnknownException().message))
+                            }
+                    }
+                }.onFailure {
+                    postSideEffect(LoginEffect.ShowSnackBar(message = it.message ?: UnknownException().message))
                 }
-            }
             intent { copy(isLoading = false) }
         }
     }
 
-    fun showToast(error: Throwable?) {
-        postSideEffect(LoginContract.LoginEffect.ShowToast(error?.message ?: "알 수 없는 에러가 발생했습니다."))
-    }
+    fun showSnackBar(message: String) = postSideEffect(LoginEffect.ShowSnackBar(message = message))
 }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/navigation/LoginSignupNavigation.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/navigation/LoginSignupNavigation.kt
@@ -31,7 +31,7 @@ fun NavGraphBuilder.loginSignupNavGraph(
         LoginRoute(
             navigateToReceived = navigateToReceived,
             navigateToSignUp = navigateToSignUp,
-            onShowSnackBar = onShowSnackBar
+            onShowSnackBar = onShowSnackBar,
         )
     }
     composable(route = LoginSignupRoute.Parent.SignUp.route) {
@@ -39,7 +39,7 @@ fun NavGraphBuilder.loginSignupNavGraph(
             padding = padding,
             navigateToReceived = navigateToReceived,
             navigateToLogin = navigateToLogin,
-            onShowToast = onShowSnackBar,
+            onShowSnackbar = onShowSnackBar,
         )
     }
 }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/navigation/LoginSignupNavigation.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/navigation/LoginSignupNavigation.kt
@@ -20,7 +20,7 @@ fun NavGraphBuilder.loginSignupNavGraph(
     navigateToLogin: () -> Unit,
     navigateToSignUp: () -> Unit,
     navigateToReceived: () -> Unit,
-    onShowToast: (SnackbarToken) -> Unit,
+    onShowSnackBar: (SnackbarToken) -> Unit,
 ) {
     composable(route = LoginSignupRoute.Parent.Vote.route) {
         VoteRoute(
@@ -31,6 +31,7 @@ fun NavGraphBuilder.loginSignupNavGraph(
         LoginRoute(
             navigateToReceived = navigateToReceived,
             navigateToSignUp = navigateToSignUp,
+            onShowSnackBar = onShowSnackBar
         )
     }
     composable(route = LoginSignupRoute.Parent.SignUp.route) {
@@ -38,7 +39,7 @@ fun NavGraphBuilder.loginSignupNavGraph(
             padding = padding,
             navigateToReceived = navigateToReceived,
             navigateToLogin = navigateToLogin,
-            onShowToast = onShowToast,
+            onShowToast = onShowSnackBar,
         )
     }
 }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
@@ -9,7 +9,8 @@ import com.susu.feature.loginsignup.R
 sealed interface SignUpEffect : SideEffect {
     data object NavigateToLogin : SignUpEffect
     data object NavigateToReceived : SignUpEffect
-    data class ShowToast(val msg: String) : SignUpEffect
+    data class ShowSnackbar(val msg: String) : SignUpEffect
+    data object ShowKakaoErrorSnackbar : SignUpEffect
 }
 
 data class SignUpState(

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpContract.kt
@@ -21,6 +21,7 @@ data class SignUpState(
     val isNameValid: Boolean = true,
     val gender: Gender = Gender.NONE,
     val birth: Int = -1,
+    val showDatePicker: Boolean = false,
 ) : UiState
 
 enum class SignUpStep(

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -42,6 +43,7 @@ import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.USER_BIRTH_RANGE
 import com.susu.core.ui.extension.collectWithLifecycle
+import com.susu.feature.loginsignup.R
 import com.susu.feature.loginsignup.signup.content.AdditionalContent
 import com.susu.feature.loginsignup.signup.content.NameContent
 import com.susu.feature.loginsignup.signup.content.TermsContent
@@ -54,8 +56,9 @@ fun SignUpRoute(
     termViewModel: TermViewModel = hiltViewModel(),
     navigateToReceived: () -> Unit,
     navigateToLogin: () -> Unit,
-    onShowToast: (SnackbarToken) -> Unit = {},
+    onShowSnackbar: (SnackbarToken) -> Unit = {},
 ) {
+    val context = LocalContext.current
     val uiState: SignUpState by viewModel.uiState.collectAsStateWithLifecycle()
     val termState: TermState by termViewModel.uiState.collectAsStateWithLifecycle()
 
@@ -69,7 +72,12 @@ fun SignUpRoute(
         when (sideEffect) {
             SignUpEffect.NavigateToLogin -> navigateToLogin()
             SignUpEffect.NavigateToReceived -> navigateToReceived()
-            is SignUpEffect.ShowToast -> onShowToast(SnackbarToken(message = sideEffect.msg))
+            is SignUpEffect.ShowSnackbar -> onShowSnackbar(SnackbarToken(message = sideEffect.msg))
+            SignUpEffect.ShowKakaoErrorSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.signup_snackbar_kakao_login_error),
+                ),
+            )
         }
     }
 

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -19,8 +19,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -61,8 +59,6 @@ fun SignUpRoute(
     val context = LocalContext.current
     val uiState: SignUpState by viewModel.uiState.collectAsStateWithLifecycle()
     val termState: TermState by termViewModel.uiState.collectAsStateWithLifecycle()
-
-    var showDatePicker by remember { mutableStateOf(false) }
 
     BackHandler {
         viewModel.goPreviousStep()
@@ -159,7 +155,7 @@ fun SignUpRoute(
                             selectedGender = uiState.gender,
                             selectedYear = uiState.birth,
                             onGenderSelect = viewModel::updateGender,
-                            onYearClick = { showDatePicker = true },
+                            onYearClick = viewModel::showDatePicker,
                         )
                     }
 
@@ -177,14 +173,14 @@ fun SignUpRoute(
             }
         }
 
-        if (showDatePicker) {
+        if (uiState.showDatePicker) {
             SusuYearPickerBottomSheet(
                 yearRange = USER_BIRTH_RANGE,
                 reverseItemOrder = true,
                 maximumContainerHeight = 322.dp,
                 onDismissRequest = {
                     viewModel.updateBirth(it)
-                    showDatePicker = false
+                    viewModel.hideDatePicker()
                 },
             )
         }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
@@ -19,6 +19,9 @@ class SignUpViewModel @Inject constructor(
     private val signUpUseCase: SignUpUseCase,
 ) : BaseViewModel<SignUpState, SignUpEffect>(SignUpState()) {
 
+    fun showDatePicker() = intent { copy(showDatePicker = true) }
+    fun hideDatePicker() = intent { copy(showDatePicker = false) }
+
     fun updateName(name: String) {
         val trimmedName = name.trim()
         if (trimmedName.length > USER_NAME_MAX_LENGTH) return

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
@@ -2,6 +2,7 @@ package com.susu.feature.loginsignup.signup
 
 import androidx.lifecycle.viewModelScope
 import com.susu.core.model.SignUpUser
+import com.susu.core.model.exception.UnknownException
 import com.susu.core.ui.Gender
 import com.susu.core.ui.SnsProviders
 import com.susu.core.ui.USER_NAME_MAX_LENGTH
@@ -92,10 +93,10 @@ class SignUpViewModel @Inject constructor(
                     ).onSuccess {
                         postSideEffect(SignUpEffect.NavigateToReceived)
                     }.onFailure {
-                        postSideEffect(SignUpEffect.ShowToast(it.message ?: "에러 발생"))
+                        postSideEffect(SignUpEffect.ShowSnackbar(it.message ?: UnknownException().message))
                     }
                 } else {
-                    postSideEffect(SignUpEffect.ShowToast("카카오톡 로그인 에러 발생"))
+                    postSideEffect(SignUpEffect.ShowKakaoErrorSnackbar)
                 }
                 intent { copy(isLoading = false) }
             }

--- a/feature/loginsignup/src/main/res/values/strings.xml
+++ b/feature/loginsignup/src/main/res/values/strings.xml
@@ -29,4 +29,5 @@
     <string name="login_snackbar_login_cancelled">로그인을 취소했습니다</string>
     <string name="login_snackbar_unknown_error">알 수 없는 에러가 발생했어요</string>
     <string name="login_snackbar_kakao_server_error">카카오톡 서버에서 에러가 발생했어요</string>
+    <string name="signup_snackbar_kakao_login_error">카카오톡 로그인 에러가 발생했어요</string>
 </resources>

--- a/feature/loginsignup/src/main/res/values/strings.xml
+++ b/feature/loginsignup/src/main/res/values/strings.xml
@@ -25,4 +25,8 @@
     <string name="signup_term_agree">동의하기</string>
     <string name="signup_name_description">반가워요!\n이름을 알려주세요</string>
     <string name="signup_additional_description">아래 정보들을 알려주시면\n통계를 알려드릴 수 있어요</string>
+    <string name="login_snackbar_kakaotalk_broswer_not_found">카카오톡 또는 브라우저를 설치해주세요</string>
+    <string name="login_snackbar_login_cancelled">로그인을 취소했습니다</string>
+    <string name="login_snackbar_unknown_error">알 수 없는 에러가 발생했어요</string>
+    <string name="login_snackbar_kakao_server_error">카카오톡 서버에서 에러가 발생했어요</string>
 </resources>

--- a/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
+++ b/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
@@ -79,7 +79,7 @@ internal fun MainScreen(
                     navigateToReceived = navigator::navigateSent,
                     navigateToLogin = navigator::navigateLogin,
                     navigateToSignUp = navigator::navigateSignup,
-                    onShowToast = viewModel::onShowSnackbar,
+                    onShowSnackBar = viewModel::onShowSnackbar,
                     padding = innerPadding,
                 )
 


### PR DESCRIPTION

## 🌱 Key changes
- 로그인
    - 카카오톡 + 브라우저 미설치 유저가 회원가입 시도 시 `카카오톡 또는 브라우저를 설치해주세요` 스낵바 노출
    - Toast 코드를 제거하여 Snackbar로 대체
    - 유저 로그인 취소, 카카오톡 서버 오류 케이스 스낵바 추가
- 회원가입
    - Toast 네이밍을 Snackbar로 대체
    -`SignUpScreen`에 존재했던 날짜선택바텀시트 상태를 `SignUpState`로 이동
