### PR TITLE
Qa/47 sent card focus

### DIFF
--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/ReceivedEnvelopeAddViewModel.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/ReceivedEnvelopeAddViewModel.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.toJavaLocalDateTime
 import kotlinx.datetime.toKotlinLocalDateTime
 import kotlinx.serialization.json.Json
-import timber.log.Timber
 import java.time.LocalDateTime
 import javax.inject.Inject
 

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/date/DateContent.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/date/DateContent.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.daangn.www.betterkoreankotlin.JosaType
 import com.susu.core.designsystem.component.bottomsheet.datepicker.SusuLimitDatePickerBottomSheet
 import com.susu.core.designsystem.component.button.GhostButtonColor
 import com.susu.core.designsystem.component.button.SmallButtonStyle
@@ -29,7 +28,6 @@ import com.susu.core.ui.util.AnnotatedText
 import com.susu.core.ui.util.currentDate
 import com.susu.core.ui.util.minDate
 import com.susu.feature.received.R
-import strings.appendJosa
 import java.time.LocalDateTime
 
 @Composable

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/date/DateContract.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/date/DateContract.kt
@@ -4,7 +4,6 @@ import com.daangn.www.betterkoreankotlin.JosaType
 import com.susu.core.ui.base.SideEffect
 import com.susu.core.ui.base.UiState
 import com.susu.core.ui.util.currentDate
-import strings.appendJosa
 import strings.getJosa
 import java.time.LocalDateTime
 
@@ -21,8 +20,11 @@ data class DateState(
 
 fun String.append은는Josa(): String {
     val josa = this.getJosa(JosaType.Type_은는)
-    return if (josa.isEmpty()) "${this}는"
-    else this + josa
+    return if (josa.isEmpty()) {
+        "${this}는"
+    } else {
+        this + josa
+    }
 }
 
 sealed interface DateSideEffect : SideEffect {

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/date/DateContract.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/date/DateContract.kt
@@ -18,6 +18,7 @@ data class DateState(
     val showOnlyStartAt: Boolean = false,
 ) : UiState
 
+@Suppress("detekt:FunctionNaming")
 fun String.append은는Josa(): String {
     val josa = this.getJosa(JosaType.Type_은는)
     return if (josa.isEmpty()) {

--- a/feature/sent/src/main/java/com/susu/feature/sent/SentContract.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/SentContract.kt
@@ -68,4 +68,5 @@ sealed interface SentEffect : SideEffect {
     data object NavigateEnvelopeSearch : SentEffect
     data class NavigateEnvelopeFilter(val filter: String) : SentEffect
     data object ScrollToTop : SentEffect
+    data class FocusToLastEnvelope(val lastIndex: Int) : SentEffect
 }

--- a/feature/sent/src/main/java/com/susu/feature/sent/SentScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/SentScreen.kt
@@ -98,6 +98,7 @@ fun SentRoute(
                 awaitFrame()
                 envelopesListState.animateScrollToItem(0)
             }
+
             is SentEffect.FocusToLastEnvelope -> scope.launch {
                 delay(500)
                 envelopesListState.animateScrollToItem(

--- a/feature/sent/src/main/java/com/susu/feature/sent/SentViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/SentViewModel.kt
@@ -165,6 +165,7 @@ class SentViewModel @Inject constructor(
         }
     }
 
+    fun moveToBottom(lastIndex: Int) = postSideEffect(SentEffect.FocusToLastEnvelope(lastIndex))
     fun navigateSentEnvelope(id: Long) = postSideEffect(SentEffect.NavigateEnvelope(id = id))
     fun navigateSentAdd() = postSideEffect(SentEffect.NavigateEnvelopeAdd)
     fun navigateSentEnvelopeSearch() = postSideEffect(SentEffect.NavigateEnvelopeSearch)

--- a/feature/sent/src/main/java/com/susu/feature/sent/SentViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/SentViewModel.kt
@@ -112,6 +112,10 @@ class SentViewModel @Inject constructor(
                     }.toPersistentList(),
                 )
             }
+
+            if (currentState.envelopesList.last().friend.id == id) {
+                moveToBottom(currentState.envelopesList.lastIndex)
+            }
         }
     }
 
@@ -165,7 +169,7 @@ class SentViewModel @Inject constructor(
         }
     }
 
-    fun moveToBottom(lastIndex: Int) = postSideEffect(SentEffect.FocusToLastEnvelope(lastIndex))
+    private fun moveToBottom(lastIndex: Int) = postSideEffect(SentEffect.FocusToLastEnvelope(lastIndex))
     fun navigateSentEnvelope(id: Long) = postSideEffect(SentEffect.NavigateEnvelope(id = id))
     fun navigateSentAdd() = postSideEffect(SentEffect.NavigateEnvelopeAdd)
     fun navigateSentEnvelopeSearch() = postSideEffect(SentEffect.NavigateEnvelopeSearch)


### PR DESCRIPTION
## 💡 Issue
- Resolved: #이슈번호

## 🌱 Key changes
보내요 최하단 봉투 펼칠 때 잘림 이슈 처리 관련 작업 진행했습니다.
해당 작업 관련 질문사항이 있어 아래 'To Reviewers'에 적었습니다!

## ✅ To Reviewers
- `SentHistoryCard`의 높이를 직접 구하는 방법을 모르겠어서, 넉넉하게 디바이스 화면 절반 정도로 잡았습니다.
마지막 아이템에 한해서 스크롤 조절을 하면 되서 일단 이렇게 구현해놨는데.. 괜찮을까욥?
- 스크롤 조절 관련해서 `delay(500)`를 준 상황입니다. 제가 현재 테스트 기기가 에뮬밖에 없는데, 굉장히 렉이 많이 걸려서 delay를 주지 않으면 처음에 build하고 난 직후에 스크롤이 잘 올라오지 않습니다.. 혹시 이 부분 관련해서 실기기로 테스트 해주시고 피드백 주실 수 있으실까요..?

## 📸 스크린샷
|![화면 기록 2024-02-15 오전 1 18 34](https://github.com/YAPP-Github/oksusu-susu-android/assets/70886911/ff3075c7-2e3e-4b06-9ff5-75d8efc45792)|
|:--:|
|최하단 봉투 잘림 이슈 해결|
