### PR TITLE
Qa/19 74 보내요 유효성 검사, 상세/편집 커스텀 항목 관련 문제

### DIFF
--- a/core/model/src/main/java/com/susu/core/model/FriendRelationship.kt
+++ b/core/model/src/main/java/com/susu/core/model/FriendRelationship.kt
@@ -9,4 +9,5 @@ data class FriendRelationship(
     val id: Long = 0,
     val friendId: Long = 0,
     val relationshipId: Long = 0,
+    val customRelation: String? = null,
 )

--- a/core/ui/src/main/java/com/susu/core/ui/Consts.kt
+++ b/core/ui/src/main/java/com/susu/core/ui/Consts.kt
@@ -21,7 +21,7 @@ val alignList
 val moneyList = persistentListOf(10_000, 30_000, 50_000, 100_000, 500_000)
 
 const val USER_NAME_MAX_LENGTH = 10
-val nameRegex = Regex("[a-zA-Z가-힣]{0,10}")
+val nameRegex = Regex("[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣]{0,10}")
 
 val USER_BIRTH_RANGE = 1930..currentDate.year
 const val MONEY_MAX_VALUE = 2_000_000_000L // TODO: 정책 확정 시 99억으로 변경

--- a/core/ui/src/main/java/com/susu/core/ui/Consts.kt
+++ b/core/ui/src/main/java/com/susu/core/ui/Consts.kt
@@ -22,6 +22,7 @@ val moneyList = persistentListOf(10_000, 30_000, 50_000, 100_000, 500_000)
 
 const val USER_NAME_MAX_LENGTH = 10
 val USER_INPUT_REGEX = Regex("[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣]{0,10}")
+val USER_INPUT_REGEX_INCLUDE_NUMBER = Regex("[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣0-9]{0,10}")
 
 val USER_BIRTH_RANGE = 1930..currentDate.year
 const val MONEY_MAX_VALUE = 2_000_000_000L // TODO: 정책 확정 시 99억으로 변경

--- a/core/ui/src/main/java/com/susu/core/ui/Consts.kt
+++ b/core/ui/src/main/java/com/susu/core/ui/Consts.kt
@@ -21,7 +21,7 @@ val alignList
 val moneyList = persistentListOf(10_000, 30_000, 50_000, 100_000, 500_000)
 
 const val USER_NAME_MAX_LENGTH = 10
-val nameRegex = Regex("[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣]{0,10}")
+val USER_INPUT_REGEX = Regex("[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣]{0,10}")
 
 val USER_BIRTH_RANGE = 1930..currentDate.year
 const val MONEY_MAX_VALUE = 2_000_000_000L // TODO: 정책 확정 시 99억으로 변경

--- a/core/ui/src/main/java/com/susu/core/ui/Consts.kt
+++ b/core/ui/src/main/java/com/susu/core/ui/Consts.kt
@@ -24,6 +24,7 @@ const val USER_NAME_MAX_LENGTH = 10
 val nameRegex = Regex("[a-zA-Z가-힣]{0,10}")
 
 val USER_BIRTH_RANGE = 1930..currentDate.year
+const val MONEY_MAX_VALUE = 2_000_000_000L // TODO: 정책 확정 시 99억으로 변경
 
 const val INTENT_ACTION_DOWNLOAD_COMPLETE = "android.intent.action.DOWNLOAD_COMPLETE"
 const val PRIVACY_POLICY_URL = "https://sites.google.com/view/team-oksusu/%ED%99%88"

--- a/core/ui/src/main/java/com/susu/core/ui/Consts.kt
+++ b/core/ui/src/main/java/com/susu/core/ui/Consts.kt
@@ -22,6 +22,7 @@ val moneyList = persistentListOf(10_000, 30_000, 50_000, 100_000, 500_000)
 
 const val USER_NAME_MAX_LENGTH = 10
 val USER_INPUT_REGEX = Regex("[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣]{0,10}")
+val USER_INPUT_REGEX_LONG = Regex("[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣0-9]{0,30}")
 val USER_INPUT_REGEX_INCLUDE_NUMBER = Regex("[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣0-9]{0,10}")
 
 val USER_BIRTH_RANGE = 1930..currentDate.year

--- a/data/src/main/java/com/susu/data/remote/model/response/EnvelopeDetailResponse.kt
+++ b/data/src/main/java/com/susu/data/remote/model/response/EnvelopeDetailResponse.kt
@@ -17,6 +17,7 @@ internal fun FriendRelationShipInfo.toModel() = FriendRelationship(
     id = id,
     friendId = friendId,
     relationshipId = relationshipId,
+    customRelation = customRelation,
 )
 
 internal fun EnvelopeDetailResponse.toModel() = EnvelopeDetail(

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
@@ -7,7 +7,7 @@ import com.susu.core.ui.Gender
 import com.susu.core.ui.SnsProviders
 import com.susu.core.ui.USER_NAME_MAX_LENGTH
 import com.susu.core.ui.base.BaseViewModel
-import com.susu.core.ui.nameRegex
+import com.susu.core.ui.USER_INPUT_REGEX
 import com.susu.domain.usecase.loginsignup.SignUpUseCase
 import com.susu.feature.loginsignup.social.KakaoLoginHelper
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -26,7 +26,7 @@ class SignUpViewModel @Inject constructor(
         val trimmedName = name.trim()
         if (trimmedName.length > USER_NAME_MAX_LENGTH) return
 
-        intent { copy(name = trimmedName, isNameValid = nameRegex.matches(trimmedName)) }
+        intent { copy(name = trimmedName, isNameValid = USER_INPUT_REGEX.matches(trimmedName)) }
     }
 
     fun updateGender(gender: Gender) {

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoContract.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/info/MyPageInfoContract.kt
@@ -3,7 +3,7 @@ package com.susu.feature.mypage.info
 import com.susu.core.ui.Gender
 import com.susu.core.ui.base.SideEffect
 import com.susu.core.ui.base.UiState
-import com.susu.core.ui.nameRegex
+import com.susu.core.ui.USER_INPUT_REGEX
 
 sealed interface MyPageInfoEffect : SideEffect {
     data object PopBackStack : MyPageInfoEffect
@@ -24,5 +24,5 @@ data class MyPageInfoState(
     val editGender: Gender = Gender.NONE,
 ) : UiState {
     val birthEdited: Boolean = userBirth != editBirth
-    val isEditNameValid: Boolean = editName.isNotEmpty() && nameRegex.matches(editName.trim())
+    val isEditNameValid: Boolean = editName.isNotEmpty() && USER_INPUT_REGEX.matches(editName.trim())
 }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/EnvelopeAddViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/EnvelopeAddViewModel.kt
@@ -3,6 +3,7 @@ package com.susu.feature.envelopeadd
 import androidx.lifecycle.viewModelScope
 import com.susu.core.model.Category
 import com.susu.core.model.Relationship
+import com.susu.core.ui.MONEY_MAX_VALUE
 import com.susu.core.ui.base.BaseViewModel
 import com.susu.domain.usecase.envelope.CreateSentEnvelopeUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -120,7 +121,7 @@ class EnvelopeAddViewModel @Inject constructor(
 
     fun updateMoney(money: Long) = intent {
         this@EnvelopeAddViewModel.money = money
-        copy(buttonEnabled = money > 0L)
+        copy(buttonEnabled = money in 1L..MONEY_MAX_VALUE)
     }
 
     fun updateName(name: String) = intent {

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/SentEnvelopeAddScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/SentEnvelopeAddScreen.kt
@@ -190,6 +190,7 @@ fun SentEnvelopeAddScreen(
 
                 EnvelopeAddStep.MEMO -> MemoContentRoute(
                     updateParentMemo = updateParentMemo,
+                    onShowSnackbar = onShowSnackbar,
                 )
             }
         }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/SentEnvelopeAddScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/SentEnvelopeAddScreen.kt
@@ -26,6 +26,7 @@ import com.susu.core.designsystem.component.button.SusuFilledButton
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.model.Category
 import com.susu.core.model.Relationship
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.core.ui.extension.susuDefaultAnimatedContentTransitionSpec
 import com.susu.feature.envelopeadd.content.category.CategoryContentRoute
@@ -45,6 +46,7 @@ fun SentEnvelopeAddRoute(
     viewModel: EnvelopeAddViewModel = hiltViewModel(),
     popBackStack: () -> Unit,
     popBackStackWithRefresh: () -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
     handleException: (Throwable, () -> Unit) -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -92,6 +94,7 @@ fun SentEnvelopeAddRoute(
         updateParentMemo = viewModel::updateMemo,
         updateParentPhoneNumber = viewModel::updatePhoneNumber,
         updateParentPresent = viewModel::updatePresent,
+        onShowSnackbar = onShowSnackbar,
     )
 }
 
@@ -113,6 +116,7 @@ fun SentEnvelopeAddScreen(
     updateParentMemo: (String?) -> Unit = {},
     updateParentPhoneNumber: (String?) -> Unit = {},
     updateParentPresent: (String?) -> Unit = {},
+    onShowSnackbar: (SnackbarToken) -> Unit = {},
 ) {
     Column(
         modifier = Modifier
@@ -139,7 +143,11 @@ fun SentEnvelopeAddScreen(
             },
         ) { targetState ->
             when (targetState) {
-                EnvelopeAddStep.MONEY -> MoneyContentRoute(updateParentMoney = updateParentMoney)
+                EnvelopeAddStep.MONEY -> MoneyContentRoute(
+                    updateParentMoney = updateParentMoney,
+                    onShowSnackbar = onShowSnackbar,
+                )
+
                 EnvelopeAddStep.NAME -> NameContentRoute(
                     updateParentName = updateParentName,
                     updateParentFriendId = updateParentFriendId,

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/SentEnvelopeAddScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/SentEnvelopeAddScreen.kt
@@ -151,6 +151,7 @@ fun SentEnvelopeAddScreen(
                 EnvelopeAddStep.NAME -> NameContentRoute(
                     updateParentName = updateParentName,
                     updateParentFriendId = updateParentFriendId,
+                    onShowSnackbar = onShowSnackbar,
                 )
 
                 EnvelopeAddStep.RELATIONSHIP -> RelationshipContentRoute(

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/SentEnvelopeAddScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/SentEnvelopeAddScreen.kt
@@ -156,6 +156,7 @@ fun SentEnvelopeAddScreen(
 
                 EnvelopeAddStep.RELATIONSHIP -> RelationshipContentRoute(
                     updateParentSelectedRelation = updateParentSelectedRelation,
+                    onShowSnackbar = onShowSnackbar,
                 )
 
                 EnvelopeAddStep.EVENT -> CategoryContentRoute(

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/SentEnvelopeAddScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/SentEnvelopeAddScreen.kt
@@ -180,6 +180,7 @@ fun SentEnvelopeAddScreen(
 
                 EnvelopeAddStep.PRESENT -> PresentContentRoute(
                     updateParentPresent = updateParentPresent,
+                    onShowSnackbar = onShowSnackbar,
                 )
 
                 EnvelopeAddStep.PHONE -> PhoneContentRoute(

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/SentEnvelopeAddScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/SentEnvelopeAddScreen.kt
@@ -186,6 +186,7 @@ fun SentEnvelopeAddScreen(
                 EnvelopeAddStep.PHONE -> PhoneContentRoute(
                     friendName = friendName,
                     updateParentPhone = updateParentPhoneNumber,
+                    onShowSnackbar = onShowSnackbar,
                 )
 
                 EnvelopeAddStep.MEMO -> MemoContentRoute(

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/SentEnvelopeAddScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/SentEnvelopeAddScreen.kt
@@ -161,6 +161,7 @@ fun SentEnvelopeAddScreen(
 
                 EnvelopeAddStep.EVENT -> CategoryContentRoute(
                     updateParentCategory = updateParentCategory,
+                    onShowSnackbar = onShowSnackbar,
                 )
 
                 EnvelopeAddStep.DATE -> DateContentRoute(

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/category/CategoryContent.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/category/CategoryContent.kt
@@ -64,7 +64,7 @@ fun CategoryContentRoute(
 
             CategoryEffect.ShowNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.sent_add_snackbar_category_validation),
+                    message = context.getString(R.string.sent_snackbar_category_validation),
                 ),
             )
         }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/category/CategoryContent.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/category/CategoryContent.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -33,6 +34,7 @@ import com.susu.core.designsystem.component.textfieldbutton.style.MediumTextFiel
 import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.model.Category
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.feature.sent.R
 import kotlinx.coroutines.android.awaitFrame
@@ -42,10 +44,12 @@ import kotlinx.coroutines.launch
 fun CategoryContentRoute(
     viewModel: CategoryViewModel = hiltViewModel(),
     updateParentCategory: (Category?) -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val focusRequester = remember { FocusRequester() }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
 
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
@@ -57,6 +61,12 @@ fun CategoryContentRoute(
                 awaitFrame()
                 focusRequester.requestFocus()
             }
+
+            CategoryEffect.ShowNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.sent_add_snackbar_category_validation),
+                ),
+            )
         }
     }
 

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/category/CategoryContract.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/category/CategoryContract.kt
@@ -19,4 +19,5 @@ data class CategoryState(
 sealed interface CategoryEffect : SideEffect {
     data object FocusCustomCategory : CategoryEffect
     data class UpdateParentCategory(val category: Category?) : CategoryEffect
+    data object ShowNotValidSnackbar : CategoryEffect
 }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/category/CategoryViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/category/CategoryViewModel.kt
@@ -2,6 +2,7 @@ package com.susu.feature.envelopeadd.content.category
 
 import androidx.lifecycle.viewModelScope
 import com.susu.core.model.Category
+import com.susu.core.ui.USER_INPUT_REGEX_INCLUDE_NUMBER
 import com.susu.core.ui.base.BaseViewModel
 import com.susu.domain.usecase.categoryconfig.GetCategoryConfigUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -44,11 +45,20 @@ class CategoryViewModel @Inject constructor(
         copy(selectedCategory = customCategory)
     }
 
-    fun updateCustomCategoryText(text: String) = intent {
-        copy(
-            selectedCategory = customCategory.copy(name = text, customCategory = text),
-            customCategory = customCategory.copy(name = text, customCategory = text),
-        )
+    fun updateCustomCategoryText(text: String) {
+        if (!USER_INPUT_REGEX_INCLUDE_NUMBER.matches(text)) { // 한글, 영문 0~10 글자
+            if (text.length > 10) { // 길이 넘친 경우
+                postSideEffect(CategoryEffect.ShowNotValidSnackbar)
+            }
+            return // 특수문자는 입력 안 됨
+        }
+
+        intent {
+            copy(
+                selectedCategory = customCategory.copy(name = text, customCategory = text),
+                customCategory = customCategory.copy(name = text, customCategory = text),
+            )
+        }
     }
 
     fun showCustomCategoryTextField() = intent {

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/memo/MemoContent.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/memo/MemoContent.kt
@@ -38,7 +38,7 @@ fun MemoContentRoute(
             is MemoSideEffect.UpdateParentMemo -> updateParentMemo(sideEffect.memo)
             MemoSideEffect.ShowNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.sent_add_snackbar_memo_validation),
+                    message = context.getString(R.string.sent_snackbar_memo_validation),
                 ),
             )
         }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/memo/MemoContent.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/memo/MemoContent.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -19,6 +20,7 @@ import com.susu.core.designsystem.component.textfield.SusuBasicTextField
 import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.Gray40
 import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.feature.sent.R
 
@@ -26,11 +28,19 @@ import com.susu.feature.sent.R
 fun MemoContentRoute(
     viewModel: MemoViewModel = hiltViewModel(),
     updateParentMemo: (String?) -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
+    val context = LocalContext.current
+
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             is MemoSideEffect.UpdateParentMemo -> updateParentMemo(sideEffect.memo)
+            MemoSideEffect.ShowNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.sent_add_snackbar_memo_validation),
+                ),
+            )
         }
     }
 
@@ -74,6 +84,7 @@ fun MemoContent(
             placeholder = stringResource(id = R.string.sent_envelope_add_memo_placeholder),
             placeholderColor = Gray40,
             modifier = modifier.fillMaxWidth(),
+            maxLines = 5,
         )
         Spacer(modifier = modifier.size(SusuTheme.spacing.spacing_xl))
     }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/memo/MemoContract.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/memo/MemoContract.kt
@@ -9,4 +9,5 @@ data class MemoState(
 
 sealed interface MemoSideEffect : SideEffect {
     data class UpdateParentMemo(val memo: String?) : MemoSideEffect
+    data object ShowNotValidSnackbar : MemoSideEffect
 }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/memo/MemoViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/memo/MemoViewModel.kt
@@ -8,8 +8,15 @@ import javax.inject.Inject
 class MemoViewModel @Inject constructor() : BaseViewModel<MemoState, MemoSideEffect>(
     MemoState(),
 ) {
-    fun updateMemo(memo: String?) = intent {
-        postSideEffect(MemoSideEffect.UpdateParentMemo(memo))
-        copy(memo = memo ?: "")
+    fun updateMemo(memo: String?) {
+        if (memo != null && memo.length > 30) {
+            postSideEffect(MemoSideEffect.ShowNotValidSnackbar)
+            return
+        }
+
+        intent {
+            postSideEffect(MemoSideEffect.UpdateParentMemo(memo))
+            copy(memo = memo ?: "")
+        }
     }
 }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/money/MoneyContent.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/money/MoneyContent.kt
@@ -12,9 +12,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -25,6 +24,7 @@ import com.susu.core.designsystem.component.button.SusuFilledButton
 import com.susu.core.designsystem.component.textfield.SusuPriceTextField
 import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.core.ui.extension.toMoneyFormat
 import com.susu.core.ui.moneyList
@@ -34,11 +34,17 @@ import com.susu.feature.sent.R
 fun MoneyContentRoute(
     viewModel: MoneyViewModel = hiltViewModel(),
     updateParentMoney: (Long) -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
+    val context = LocalContext.current
+
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             is MoneyEffect.UpdateParentMoney -> updateParentMoney(sideEffect.money)
+            MoneyEffect.ShowNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(message = context.getString(R.string.sent_add_snackbar_money_validation)),
+            )
         }
     }
 
@@ -81,6 +87,7 @@ fun MoneyContent(
         SusuPriceTextField(
             text = uiState.money,
             onTextChange = onTextChangeMoney,
+            maxLines = 2,
             placeholder = stringResource(R.string.sent_envelope_add_money_placeholder),
         )
         Spacer(

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/money/MoneyContent.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/money/MoneyContent.kt
@@ -43,7 +43,7 @@ fun MoneyContentRoute(
         when (sideEffect) {
             is MoneyEffect.UpdateParentMoney -> updateParentMoney(sideEffect.money)
             MoneyEffect.ShowNotValidSnackbar -> onShowSnackbar(
-                SnackbarToken(message = context.getString(R.string.sent_add_snackbar_money_validation)),
+                SnackbarToken(message = context.getString(R.string.sent_snackbar_money_validation)),
             )
         }
     }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/money/MoneyContract.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/money/MoneyContract.kt
@@ -9,4 +9,5 @@ data class MoneyState(
 
 sealed interface MoneyEffect : SideEffect {
     data class UpdateParentMoney(val money: Long) : MoneyEffect
+    data object ShowNotValidSnackbar : MoneyEffect
 }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/money/MoneyViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/money/MoneyViewModel.kt
@@ -1,5 +1,6 @@
 package com.susu.feature.envelopeadd.content.money
 
+import com.susu.core.ui.MONEY_MAX_VALUE
 import com.susu.core.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -7,17 +8,31 @@ import javax.inject.Inject
 @HiltViewModel
 class MoneyViewModel @Inject constructor() : BaseViewModel<MoneyState, MoneyEffect>(MoneyState()) {
 
-    fun updateMoney(money: String) = intent {
-        postSideEffect(MoneyEffect.UpdateParentMoney(money.toLongOrNull() ?: 0))
-        copy(money = money)
+    fun updateMoney(money: String) {
+        if (money.length > 10) {
+            postSideEffect(MoneyEffect.ShowNotValidSnackbar)
+            return
+        }
+
+        intent {
+            postSideEffect(MoneyEffect.UpdateParentMoney(money.toLongOrNull() ?: 0))
+            copy(money = money)
+        }
     }
 
-    fun addMoney(money: Int) = intent {
-        val currentMoney = this.money.toLongOrNull() ?: 0
+    fun addMoney(money: Int) {
+        val currentMoney = currentState.money.toLongOrNull() ?: 0
         val addedMoney = money + currentMoney
+        if (addedMoney > MONEY_MAX_VALUE) {
+            postSideEffect(MoneyEffect.ShowNotValidSnackbar)
+            return
+        }
         postSideEffect(MoneyEffect.UpdateParentMoney(addedMoney))
-        copy(
-            money = addedMoney.toString(),
-        )
+
+        intent {
+            copy(
+                money = addedMoney.toString(),
+            )
+        }
     }
 }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/name/NameContent.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/name/NameContent.kt
@@ -15,11 +15,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -30,6 +30,7 @@ import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.Gray40
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.model.FriendSearch
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.feature.envelopeadd.content.component.FriendListItem
 import com.susu.feature.sent.R
@@ -42,8 +43,10 @@ fun NameContentRoute(
     viewModel: NameViewModel = hiltViewModel(),
     updateParentName: (String) -> Unit,
     updateParentFriendId: (Long?) -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
     val focusManager = LocalFocusManager.current
     val focusRequester = remember { FocusRequester() }
 
@@ -52,6 +55,11 @@ fun NameContentRoute(
             NameEffect.FocusClear -> focusManager.clearFocus()
             is NameEffect.UpdateParentFriendId -> updateParentFriendId(sideEffect.friendId)
             is NameEffect.UpdateParentName -> updateParentName(sideEffect.name)
+            NameEffect.ShowNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.sent_add_snackbar_name_validation),
+                ),
+            )
         }
     }
 

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/name/NameContent.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/name/NameContent.kt
@@ -57,7 +57,7 @@ fun NameContentRoute(
             is NameEffect.UpdateParentName -> updateParentName(sideEffect.name)
             NameEffect.ShowNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.sent_add_snackbar_name_validation),
+                    message = context.getString(R.string.sent_snackbar_name_validation),
                 ),
             )
         }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/name/NameContract.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/name/NameContract.kt
@@ -16,4 +16,5 @@ sealed interface NameEffect : SideEffect {
     data class UpdateParentName(val name: String) : NameEffect
     data class UpdateParentFriendId(val friendId: Long?) : NameEffect
     data object FocusClear : NameEffect
+    data object ShowNotValidSnackbar : NameEffect
 }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/name/NameViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/name/NameViewModel.kt
@@ -3,7 +3,7 @@ package com.susu.feature.envelopeadd.content.name
 import androidx.lifecycle.viewModelScope
 import com.susu.core.model.FriendSearch
 import com.susu.core.ui.base.BaseViewModel
-import com.susu.core.ui.nameRegex
+import com.susu.core.ui.USER_INPUT_REGEX
 import com.susu.domain.usecase.friend.SearchFriendUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
@@ -17,7 +17,7 @@ class NameViewModel @Inject constructor(
 ) : BaseViewModel<NameState, NameEffect>(NameState()) {
 
     fun updateName(name: String) {
-        if (!nameRegex.matches(name)) { // 한글, 영문 0~10 글자
+        if (!USER_INPUT_REGEX.matches(name)) { // 한글, 영문 0~10 글자
             if (name.length > 10) { // 길이 넘친 경우
                 postSideEffect(NameEffect.ShowNotValidSnackbar)
             }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/name/NameViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/name/NameViewModel.kt
@@ -3,6 +3,7 @@ package com.susu.feature.envelopeadd.content.name
 import androidx.lifecycle.viewModelScope
 import com.susu.core.model.FriendSearch
 import com.susu.core.ui.base.BaseViewModel
+import com.susu.core.ui.nameRegex
 import com.susu.domain.usecase.friend.SearchFriendUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
@@ -15,16 +16,25 @@ class NameViewModel @Inject constructor(
     private val searchFriendUseCase: SearchFriendUseCase,
 ) : BaseViewModel<NameState, NameEffect>(NameState()) {
 
-    fun updateName(name: String) = intent {
-        postSideEffect(
-            NameEffect.UpdateParentName(name),
-            NameEffect.UpdateParentFriendId(null),
-        )
-        copy(
-            name = name,
-            friendList = if (name.isEmpty()) persistentListOf() else friendList,
-            isSelectedFriend = false,
-        )
+    fun updateName(name: String) {
+        if (!nameRegex.matches(name)) { // 한글, 영문 0~10 글자
+            if (name.length > 10) { // 길이 넘친 경우
+                postSideEffect(NameEffect.ShowNotValidSnackbar)
+            }
+            return // 특수문자는 입력 안 됨
+        }
+
+        intent {
+            postSideEffect(
+                NameEffect.UpdateParentName(name),
+                NameEffect.UpdateParentFriendId(null),
+            )
+            copy(
+                name = name,
+                friendList = if (name.isEmpty()) persistentListOf() else friendList,
+                isSelectedFriend = false,
+            )
+        }
     }
 
     fun selectFriend(friend: FriendSearch) = intent {

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/phone/PhoneContent.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/phone/PhoneContent.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
@@ -20,6 +21,7 @@ import com.susu.core.designsystem.component.textfield.SusuBasicTextField
 import com.susu.core.designsystem.theme.Gray40
 import com.susu.core.designsystem.theme.Gray60
 import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.core.ui.util.AnnotatedText
 import com.susu.feature.sent.R
@@ -29,11 +31,19 @@ fun PhoneContentRoute(
     viewModel: PhoneViewModel = hiltViewModel(),
     friendName: String,
     updateParentPhone: (String?) -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
+    val context = LocalContext.current
+
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             is PhoneSideEffect.UpdateParentPhone -> updateParentPhone(sideEffect.phone)
+            PhoneSideEffect.ShowNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.sent_add_snackbar_phone_validation),
+                ),
+            )
         }
     }
 

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/phone/PhoneContent.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/phone/PhoneContent.kt
@@ -41,7 +41,7 @@ fun PhoneContentRoute(
             is PhoneSideEffect.UpdateParentPhone -> updateParentPhone(sideEffect.phone)
             PhoneSideEffect.ShowNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.sent_add_snackbar_phone_validation),
+                    message = context.getString(R.string.sent_snackbar_phone_validation),
                 ),
             )
         }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/phone/PhoneContract.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/phone/PhoneContract.kt
@@ -10,4 +10,5 @@ data class PhoneState(
 
 sealed interface PhoneSideEffect : SideEffect {
     data class UpdateParentPhone(val phone: String?) : PhoneSideEffect
+    data object ShowNotValidSnackbar : PhoneSideEffect
 }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/phone/PhoneViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/phone/PhoneViewModel.kt
@@ -9,8 +9,15 @@ class PhoneViewModel @Inject constructor() : BaseViewModel<PhoneState, PhoneSide
     PhoneState(),
 ) {
     fun updateName(name: String) = intent { copy(name = name) }
-    fun updatePhone(phone: String?) = intent {
-        postSideEffect(PhoneSideEffect.UpdateParentPhone(phone))
-        copy(phone = phone ?: "")
+    fun updatePhone(phone: String?) {
+        if (phone != null && phone.length > 11) {
+            postSideEffect(PhoneSideEffect.ShowNotValidSnackbar)
+            return
+        }
+
+        intent {
+            postSideEffect(PhoneSideEffect.UpdateParentPhone(phone))
+            copy(phone = phone ?: "")
+        }
     }
 }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/present/PresentContent.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/present/PresentContent.kt
@@ -38,7 +38,7 @@ fun PresentContentRoute(
             is PresentSideEffect.UpdateParentPresent -> updateParentPresent(sideEffect.present)
             PresentSideEffect.ShowNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.sent_add_snackbar_present_validation),
+                    message = context.getString(R.string.sent_snackbar_present_validation),
                 ),
             )
         }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/present/PresentContent.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/present/PresentContent.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -19,6 +20,7 @@ import com.susu.core.designsystem.component.textfield.SusuBasicTextField
 import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.Gray40
 import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.feature.sent.R
 
@@ -26,11 +28,19 @@ import com.susu.feature.sent.R
 fun PresentContentRoute(
     viewModel: PresentViewModel = hiltViewModel(),
     updateParentPresent: (String?) -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
+    val context = LocalContext.current
+
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             is PresentSideEffect.UpdateParentPresent -> updateParentPresent(sideEffect.present)
+            PresentSideEffect.ShowNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.sent_add_snackbar_present_validation),
+                ),
+            )
         }
     }
 
@@ -74,6 +84,7 @@ fun PresentContent(
             placeholder = stringResource(id = R.string.sent_envelope_add_present_placeholder),
             placeholderColor = Gray40,
             modifier = modifier.fillMaxWidth(),
+            maxLines = 5,
         )
         Spacer(modifier = modifier.size(SusuTheme.spacing.spacing_xl))
     }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/present/PresentContract.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/present/PresentContract.kt
@@ -9,4 +9,5 @@ data class PresentState(
 
 sealed interface PresentSideEffect : SideEffect {
     data class UpdateParentPresent(val present: String?) : PresentSideEffect
+    data object ShowNotValidSnackbar : PresentSideEffect
 }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/present/PresentViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/present/PresentViewModel.kt
@@ -1,5 +1,6 @@
 package com.susu.feature.envelopeadd.content.present
 
+import com.susu.core.ui.USER_INPUT_REGEX_LONG
 import com.susu.core.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -8,8 +9,17 @@ import javax.inject.Inject
 class PresentViewModel @Inject constructor() : BaseViewModel<PresentState, PresentSideEffect>(
     PresentState(),
 ) {
-    fun updatePresent(present: String?) = intent {
-        postSideEffect(PresentSideEffect.UpdateParentPresent(present))
-        copy(present = present ?: "")
+    fun updatePresent(present: String?) {
+        if (present != null && !USER_INPUT_REGEX_LONG.matches(present)) {
+            if (present.length > 30) {
+                postSideEffect(PresentSideEffect.ShowNotValidSnackbar)
+            }
+            return
+        }
+
+        intent {
+            postSideEffect(PresentSideEffect.UpdateParentPresent(present))
+            copy(present = present ?: "")
+        }
     }
 }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/relationship/RelationshipContent.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/relationship/RelationshipContent.kt
@@ -13,13 +13,12 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -35,6 +34,7 @@ import com.susu.core.designsystem.component.textfieldbutton.style.MediumTextFiel
 import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.model.Relationship
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.feature.sent.R
 import kotlinx.coroutines.android.awaitFrame
@@ -44,10 +44,12 @@ import kotlinx.coroutines.launch
 fun RelationshipContentRoute(
     viewModel: RelationshipViewModel = hiltViewModel(),
     updateParentSelectedRelation: (Relationship?) -> Unit = {},
+    onShowSnackbar: (SnackbarToken) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val focusRequester = remember { FocusRequester() }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
 
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
@@ -59,6 +61,10 @@ fun RelationshipContentRoute(
                 awaitFrame()
                 focusRequester.requestFocus()
             }
+
+            RelationShipSideEffect.ShowNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(message = context.getString(R.string.sent_add_snackbar_relationship_validation)),
+            )
         }
     }
 

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/relationship/RelationshipContent.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/relationship/RelationshipContent.kt
@@ -63,7 +63,7 @@ fun RelationshipContentRoute(
             }
 
             RelationShipSideEffect.ShowNotValidSnackbar -> onShowSnackbar(
-                SnackbarToken(message = context.getString(R.string.sent_add_snackbar_relationship_validation)),
+                SnackbarToken(message = context.getString(R.string.sent_snackbar_relationship_validation)),
             )
         }
     }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/relationship/RelationshipContract.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/relationship/RelationshipContract.kt
@@ -19,4 +19,5 @@ data class RelationShipState(
 sealed interface RelationShipSideEffect : SideEffect {
     data object FocusCustomRelationShip : RelationShipSideEffect
     data class UpdateParentSelectedRelationShip(val relationShip: Relationship?) : RelationShipSideEffect
+    data object ShowNotValidSnackbar : RelationShipSideEffect
 }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/relationship/RelationshipViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/relationship/RelationshipViewModel.kt
@@ -2,6 +2,7 @@ package com.susu.feature.envelopeadd.content.relationship
 
 import androidx.lifecycle.viewModelScope
 import com.susu.core.model.Relationship
+import com.susu.core.ui.USER_INPUT_REGEX
 import com.susu.core.ui.base.BaseViewModel
 import com.susu.domain.usecase.envelope.GetRelationShipConfigListUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -50,11 +51,20 @@ class RelationshipViewModel @Inject constructor(
         copy(selectedRelationship = customRelationship)
     }
 
-    fun updateCustomRelationShipText(text: String) = intent {
-        copy(
-            selectedRelationship = customRelationship.copy(customRelation = text),
-            customRelationship = customRelationship.copy(customRelation = text),
-        )
+    fun updateCustomRelationShipText(text: String) {
+        if (!USER_INPUT_REGEX.matches(text)) { // 한글, 영문 0~10 글자
+            if (text.length > 10) { // 길이 넘친 경우
+                postSideEffect(RelationShipSideEffect.ShowNotValidSnackbar)
+            }
+            return // 특수문자는 입력 안 됨
+        }
+
+        intent {
+            copy(
+                selectedRelationship = customRelationship.copy(customRelation = text),
+                customRelationship = customRelationship.copy(customRelation = text),
+            )
+        }
     }
 
     fun showCustomRelationShipTextField() = intent {

--- a/feature/sent/src/main/java/com/susu/feature/envelopedetail/SentEnvelopeDetailScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopedetail/SentEnvelopeDetailScreen.kt
@@ -55,6 +55,7 @@ fun SentEnvelopeDetailRoute(
             SentEnvelopeDetailEffect.PopBackStack -> {
                 editedFriendId?.let { popBackStackWithEditedFriendId(it) } ?: popBackStack()
             }
+
             is SentEnvelopeDetailEffect.NavigateEnvelopeEdit -> navigateSentEnvelopeEdit(sideEffect.envelopeDetail)
             SentEnvelopeDetailEffect.ShowDeleteDialog -> onShowDialog(
                 DialogToken(
@@ -145,7 +146,11 @@ fun SentEnvelopeDetailScreen(
                     Column {
                         DetailItem(
                             categoryText = stringResource(com.susu.core.ui.R.string.word_event),
-                            contentText = category.category,
+                            contentText = if (category.customCategory != null) {
+                                category.customCategory!!
+                            } else {
+                                category.category
+                            },
                             isEmptyContent = category.category.isEmpty(),
                         )
                         DetailItem(
@@ -155,7 +160,11 @@ fun SentEnvelopeDetailScreen(
                         )
                         DetailItem(
                             categoryText = stringResource(com.susu.core.ui.R.string.word_relationship),
-                            contentText = relationship.relation,
+                            contentText = if (friendRelationship.customRelation != null) {
+                                friendRelationship.customRelation!!
+                            } else {
+                                relationship.relation
+                            },
                             isEmptyContent = relationship.relation.isEmpty(),
                         )
                         DetailItem(

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditContract.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditContract.kt
@@ -37,4 +37,11 @@ sealed interface SentEnvelopeEditSideEffect : SideEffect {
     data class HandleException(val throwable: Throwable, val retry: () -> Unit) : SentEnvelopeEditSideEffect
     data object FocusCustomCategory : SentEnvelopeEditSideEffect
     data object FocusCustomRelationship : SentEnvelopeEditSideEffect
+    data object ShowMoneyNotValidSnackbar : SentEnvelopeEditSideEffect
+    data object ShowNameNotValidSnackbar : SentEnvelopeEditSideEffect
+    data object ShowRelationshipNotValidSnackbar : SentEnvelopeEditSideEffect
+    data object ShowCategoryNotValidSnackbar : SentEnvelopeEditSideEffect
+    data object ShowPresentNotValidSnackbar : SentEnvelopeEditSideEffect
+    data object ShowMemoNotValidSnackbar : SentEnvelopeEditSideEffect
+    data object ShowPhoneNotValidSnackbar : SentEnvelopeEditSideEffect
 }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
@@ -95,38 +95,44 @@ fun SentEnvelopeEditRoute(
             is SentEnvelopeEditSideEffect.PopBackStackWithEditedFriendId -> popBackStackWithEditedFriendId(sideEffect.id)
             SentEnvelopeEditSideEffect.ShowCategoryNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.sent_snackbar_category_validation)
-                )
+                    message = context.getString(R.string.sent_snackbar_category_validation),
+                ),
             )
+
             SentEnvelopeEditSideEffect.ShowMemoNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.sent_snackbar_memo_validation)
-                )
+                    message = context.getString(R.string.sent_snackbar_memo_validation),
+                ),
             )
+
             SentEnvelopeEditSideEffect.ShowMoneyNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.sent_snackbar_money_validation)
-                )
+                    message = context.getString(R.string.sent_snackbar_money_validation),
+                ),
             )
+
             SentEnvelopeEditSideEffect.ShowNameNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.sent_snackbar_name_validation)
-                )
+                    message = context.getString(R.string.sent_snackbar_name_validation),
+                ),
             )
+
             SentEnvelopeEditSideEffect.ShowPhoneNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.sent_snackbar_phone_validation)
-                )
+                    message = context.getString(R.string.sent_snackbar_phone_validation),
+                ),
             )
+
             SentEnvelopeEditSideEffect.ShowPresentNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.sent_snackbar_present_validation)
-                )
+                    message = context.getString(R.string.sent_snackbar_present_validation),
+                ),
             )
+
             SentEnvelopeEditSideEffect.ShowRelationshipNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.sent_snackbar_relationship_validation)
-                )
+                    message = context.getString(R.string.sent_snackbar_relationship_validation),
+                ),
             )
         }
     }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
@@ -51,6 +52,7 @@ import com.susu.core.designsystem.theme.Gray70
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.model.Category
 import com.susu.core.model.Relationship
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.core.ui.extension.susuClickable
 import com.susu.core.ui.util.to_yyyy_korYear_M_korMonth_d_korDay
@@ -64,11 +66,13 @@ fun SentEnvelopeEditRoute(
     viewModel: SentEnvelopeEditViewModel = hiltViewModel(),
     popBackStack: () -> Unit,
     popBackStackWithEditedFriendId: (Long) -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val categoryFocusRequester = remember { FocusRequester() }
     val relationshipFocusRequester = remember { FocusRequester() }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
 
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
@@ -89,6 +93,41 @@ fun SentEnvelopeEditRoute(
             }
 
             is SentEnvelopeEditSideEffect.PopBackStackWithEditedFriendId -> popBackStackWithEditedFriendId(sideEffect.id)
+            SentEnvelopeEditSideEffect.ShowCategoryNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.sent_add_snackbar_category_validation)
+                )
+            )
+            SentEnvelopeEditSideEffect.ShowMemoNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.sent_add_snackbar_memo_validation)
+                )
+            )
+            SentEnvelopeEditSideEffect.ShowMoneyNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.sent_add_snackbar_money_validation)
+                )
+            )
+            SentEnvelopeEditSideEffect.ShowNameNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.sent_add_snackbar_name_validation)
+                )
+            )
+            SentEnvelopeEditSideEffect.ShowPhoneNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.sent_add_snackbar_phone_validation)
+                )
+            )
+            SentEnvelopeEditSideEffect.ShowPresentNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.sent_add_snackbar_present_validation)
+                )
+            )
+            SentEnvelopeEditSideEffect.ShowRelationshipNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.sent_add_snackbar_relationship_validation)
+                )
+            )
         }
     }
 
@@ -191,6 +230,7 @@ fun SentEnvelopeEditScreen(
                     onTextChange = { onMoneyUpdated(it.toLongOrNull() ?: 0L) },
                     textStyle = SusuTheme.typography.title_xxl,
                     modifier = Modifier.fillMaxWidth(),
+                    maxLines = 2,
                 )
                 Spacer(modifier = Modifier.size(SusuTheme.spacing.spacing_m))
                 EditDetailItem(
@@ -237,6 +277,7 @@ fun SentEnvelopeEditScreen(
                         placeholderColor = Gray30,
                         textStyle = SusuTheme.typography.title_s,
                         modifier = Modifier.fillMaxWidth(),
+                        maxLines = 2,
                     )
                 }
                 EditDetailItem(
@@ -321,6 +362,7 @@ fun SentEnvelopeEditScreen(
                         placeholderColor = Gray30,
                         textStyle = SusuTheme.typography.title_s,
                         modifier = Modifier.fillMaxWidth(),
+                        maxLines = 3,
                     )
                 }
                 EditDetailItem(
@@ -336,6 +378,7 @@ fun SentEnvelopeEditScreen(
                         textStyle = SusuTheme.typography.title_s,
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                         modifier = Modifier.fillMaxWidth(),
+                        maxLines = 2,
                     )
                 }
                 EditDetailItem(
@@ -349,7 +392,7 @@ fun SentEnvelopeEditScreen(
                         placeholder = stringResource(R.string.sent_envelope_edit_category_memo_placeholder),
                         placeholderColor = Gray30,
                         textStyle = SusuTheme.typography.title_s,
-                        maxLines = 2,
+                        maxLines = 3,
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
@@ -95,37 +95,37 @@ fun SentEnvelopeEditRoute(
             is SentEnvelopeEditSideEffect.PopBackStackWithEditedFriendId -> popBackStackWithEditedFriendId(sideEffect.id)
             SentEnvelopeEditSideEffect.ShowCategoryNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.sent_add_snackbar_category_validation)
+                    message = context.getString(R.string.sent_snackbar_category_validation)
                 )
             )
             SentEnvelopeEditSideEffect.ShowMemoNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.sent_add_snackbar_memo_validation)
+                    message = context.getString(R.string.sent_snackbar_memo_validation)
                 )
             )
             SentEnvelopeEditSideEffect.ShowMoneyNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.sent_add_snackbar_money_validation)
+                    message = context.getString(R.string.sent_snackbar_money_validation)
                 )
             )
             SentEnvelopeEditSideEffect.ShowNameNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.sent_add_snackbar_name_validation)
+                    message = context.getString(R.string.sent_snackbar_name_validation)
                 )
             )
             SentEnvelopeEditSideEffect.ShowPhoneNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.sent_add_snackbar_phone_validation)
+                    message = context.getString(R.string.sent_snackbar_phone_validation)
                 )
             )
             SentEnvelopeEditSideEffect.ShowPresentNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.sent_add_snackbar_present_validation)
+                    message = context.getString(R.string.sent_snackbar_present_validation)
                 )
             )
             SentEnvelopeEditSideEffect.ShowRelationshipNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.sent_add_snackbar_relationship_validation)
+                    message = context.getString(R.string.sent_snackbar_relationship_validation)
                 )
             )
         }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditViewModel.kt
@@ -105,7 +105,7 @@ class SentEnvelopeEditViewModel @Inject constructor(
 
     fun updateAmount(amount: Long) {
         if (amount > MONEY_MAX_VALUE) {
-            postSideEffect(SentEnvelopeEditSideEffect.ShowMemoNotValidSnackbar)
+            postSideEffect(SentEnvelopeEditSideEffect.ShowMoneyNotValidSnackbar)
             return
         }
         intent { copy(amount = amount) }

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditViewModel.kt
@@ -3,6 +3,10 @@ package com.susu.feature.envelopeedit
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.susu.core.model.EnvelopeDetail
+import com.susu.core.ui.MONEY_MAX_VALUE
+import com.susu.core.ui.USER_INPUT_REGEX
+import com.susu.core.ui.USER_INPUT_REGEX_INCLUDE_NUMBER
+import com.susu.core.ui.USER_INPUT_REGEX_LONG
 import com.susu.core.ui.base.BaseViewModel
 import com.susu.core.ui.extension.decodeFromUri
 import com.susu.core.ui.util.getSafeLocalDateTime
@@ -100,14 +104,28 @@ class SentEnvelopeEditViewModel @Inject constructor(
     fun popBackStack() = postSideEffect(SentEnvelopeEditSideEffect.PopBackStack)
 
     fun updateAmount(amount: Long) {
+        if (amount > MONEY_MAX_VALUE) {
+            postSideEffect(SentEnvelopeEditSideEffect.ShowMemoNotValidSnackbar)
+            return
+        }
         intent { copy(amount = amount) }
     }
 
     fun updateGift(gift: String?) {
+        if (gift != null && !USER_INPUT_REGEX_LONG.matches(gift)) {
+            if (gift.length > 30) {
+                postSideEffect(SentEnvelopeEditSideEffect.ShowPresentNotValidSnackbar)
+            }
+            return
+        }
         intent { copy(gift = gift?.ifEmpty { null }) }
     }
 
     fun updateMemo(memo: String?) {
+        if (memo != null && memo.length > 30) {
+            postSideEffect(SentEnvelopeEditSideEffect.ShowPresentNotValidSnackbar)
+            return
+        }
         intent { copy(memo = memo?.ifEmpty { null }) }
     }
 
@@ -126,6 +144,12 @@ class SentEnvelopeEditViewModel @Inject constructor(
     }
 
     fun updateFriendName(name: String) {
+        if (!USER_INPUT_REGEX.matches(name)) {
+            if (name.length > 10) {
+                postSideEffect(SentEnvelopeEditSideEffect.ShowNameNotValidSnackbar)
+            }
+            return
+        }
         intent { copy(friendName = name) }
     }
 
@@ -134,10 +158,20 @@ class SentEnvelopeEditViewModel @Inject constructor(
     }
 
     fun updateCustomRelationship(customRelationship: String) {
+        if (!USER_INPUT_REGEX.matches(customRelationship)) {
+            if (customRelationship.length > 10) {
+                postSideEffect(SentEnvelopeEditSideEffect.ShowRelationshipNotValidSnackbar)
+            }
+            return
+        }
         intent { copy(customRelationship = customRelationship) }
     }
 
     fun updatePhoneNumber(phoneNumber: String?) {
+        if (phoneNumber != null && phoneNumber.length > 11) {
+            postSideEffect(SentEnvelopeEditSideEffect.ShowPhoneNotValidSnackbar)
+            return
+        }
         intent { copy(phoneNumber = phoneNumber?.ifEmpty { null }) }
     }
 
@@ -146,6 +180,12 @@ class SentEnvelopeEditViewModel @Inject constructor(
     }
 
     fun updateCustomCategory(customCategory: String?) {
+        if (customCategory != null && !USER_INPUT_REGEX_INCLUDE_NUMBER.matches(customCategory)) {
+            if (customCategory.length > 10) {
+                postSideEffect(SentEnvelopeEditSideEffect.ShowCategoryNotValidSnackbar)
+            }
+            return
+        }
         intent { copy(customCategory = customCategory) }
     }
 

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditViewModel.kt
@@ -55,7 +55,7 @@ class SentEnvelopeEditViewModel @Inject constructor(
                             handedOverAt = envelope.handedOverAt.toJavaLocalDateTime(),
                             friendName = friend.name,
                             relationshipId = relationship.id,
-                            customRelationship = relationship.customRelation,
+                            customRelationship = friendRelationship.customRelation,
                             phoneNumber = friend.phoneNumber.ifEmpty { null },
                             categoryId = category.id,
                             customCategory = category.customCategory,

--- a/feature/sent/src/main/java/com/susu/feature/sent/navigation/SentNavigation.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/navigation/SentNavigation.kt
@@ -138,6 +138,7 @@ fun NavGraphBuilder.sentNavGraph(
             popBackStack = popBackStack,
             popBackStackWithRefresh = popBackStackWithRefresh,
             handleException = handleException,
+            onShowSnackbar = onShowSnackbar,
         )
     }
 

--- a/feature/sent/src/main/java/com/susu/feature/sent/navigation/SentNavigation.kt
+++ b/feature/sent/src/main/java/com/susu/feature/sent/navigation/SentNavigation.kt
@@ -130,6 +130,7 @@ fun NavGraphBuilder.sentNavGraph(
         SentEnvelopeEditRoute(
             popBackStack = popBackStack,
             popBackStackWithEditedFriendId = popBackStackWithEditedFriendId,
+            onShowSnackbar = onShowSnackbar,
         )
     }
 

--- a/feature/sent/src/main/res/values/strings.xml
+++ b/feature/sent/src/main/res/values/strings.xml
@@ -64,4 +64,5 @@
     <string name="sent_add_snackbar_category_validation">경조사는 10글자까지만 입력 가능해요</string>
     <string name="sent_add_snackbar_present_validation">선물은 30글자까지만 입력 가능해요</string>
     <string name="sent_add_snackbar_memo_validation">메모는 30글자까지만 입력 가능해요</string>
+    <string name="sent_add_snackbar_phone_validation">연락처는 11자리까지만 입력 가능해요</string>
 </resources>

--- a/feature/sent/src/main/res/values/strings.xml
+++ b/feature/sent/src/main/res/values/strings.xml
@@ -58,11 +58,12 @@
     <string name="sent_envelope_detail_delete_snackbar">봉투가 삭제됐어요</string>
     <string name="sent_add_more_step_phone">받은 이의 연락처</string>
     <string name="envelope_filter_total_money">전체 금액</string>
-    <string name="sent_add_snackbar_money_validation">금액은 20억원까지만 입력 가능해요</string>
-    <string name="sent_add_snackbar_name_validation">이름은 10글자까지만 입력 가능해요</string>
-    <string name="sent_add_snackbar_relationship_validation">나와의 관계는 10글자까지만 입력 가능해요</string>
-    <string name="sent_add_snackbar_category_validation">경조사는 10글자까지만 입력 가능해요</string>
-    <string name="sent_add_snackbar_present_validation">선물은 30글자까지만 입력 가능해요</string>
-    <string name="sent_add_snackbar_memo_validation">메모는 30글자까지만 입력 가능해요</string>
-    <string name="sent_add_snackbar_phone_validation">연락처는 11자리까지만 입력 가능해요</string>
+
+    <string name="sent_snackbar_money_validation">금액은 20억원까지만 입력 가능해요</string>
+    <string name="sent_snackbar_name_validation">이름은 10글자까지만 입력 가능해요</string>
+    <string name="sent_snackbar_relationship_validation">나와의 관계는 10글자까지만 입력 가능해요</string>
+    <string name="sent_snackbar_category_validation">경조사는 10글자까지만 입력 가능해요</string>
+    <string name="sent_snackbar_present_validation">선물은 30글자까지만 입력 가능해요</string>
+    <string name="sent_snackbar_memo_validation">메모는 30글자까지만 입력 가능해요</string>
+    <string name="sent_snackbar_phone_validation">연락처는 11자리까지만 입력 가능해요</string>
 </resources>

--- a/feature/sent/src/main/res/values/strings.xml
+++ b/feature/sent/src/main/res/values/strings.xml
@@ -58,4 +58,5 @@
     <string name="sent_envelope_detail_delete_snackbar">봉투가 삭제됐어요</string>
     <string name="sent_add_more_step_phone">받은 이의 연락처</string>
     <string name="envelope_filter_total_money">전체 금액</string>
+    <string name="sent_add_snackbar_money_validation">금액은 20억원까지만 입력 가능해요</string>
 </resources>

--- a/feature/sent/src/main/res/values/strings.xml
+++ b/feature/sent/src/main/res/values/strings.xml
@@ -61,4 +61,5 @@
     <string name="sent_add_snackbar_money_validation">금액은 20억원까지만 입력 가능해요</string>
     <string name="sent_add_snackbar_name_validation">이름은 10글자까지만 입력 가능해요</string>
     <string name="sent_add_snackbar_relationship_validation">나와의 관계는 10글자까지만 입력 가능해요</string>
+    <string name="sent_add_snackbar_category_validation">경조사는 10글자까지만 입력 가능해요</string>
 </resources>

--- a/feature/sent/src/main/res/values/strings.xml
+++ b/feature/sent/src/main/res/values/strings.xml
@@ -59,4 +59,5 @@
     <string name="sent_add_more_step_phone">받은 이의 연락처</string>
     <string name="envelope_filter_total_money">전체 금액</string>
     <string name="sent_add_snackbar_money_validation">금액은 20억원까지만 입력 가능해요</string>
+    <string name="sent_add_snackbar_name_validation">이름은 10글자까지만 입력 가능해요</string>
 </resources>

--- a/feature/sent/src/main/res/values/strings.xml
+++ b/feature/sent/src/main/res/values/strings.xml
@@ -62,4 +62,5 @@
     <string name="sent_add_snackbar_name_validation">이름은 10글자까지만 입력 가능해요</string>
     <string name="sent_add_snackbar_relationship_validation">나와의 관계는 10글자까지만 입력 가능해요</string>
     <string name="sent_add_snackbar_category_validation">경조사는 10글자까지만 입력 가능해요</string>
+    <string name="sent_add_snackbar_present_validation">선물은 30글자까지만 입력 가능해요</string>
 </resources>

--- a/feature/sent/src/main/res/values/strings.xml
+++ b/feature/sent/src/main/res/values/strings.xml
@@ -60,4 +60,5 @@
     <string name="envelope_filter_total_money">전체 금액</string>
     <string name="sent_add_snackbar_money_validation">금액은 20억원까지만 입력 가능해요</string>
     <string name="sent_add_snackbar_name_validation">이름은 10글자까지만 입력 가능해요</string>
+    <string name="sent_add_snackbar_relationship_validation">나와의 관계는 10글자까지만 입력 가능해요</string>
 </resources>

--- a/feature/sent/src/main/res/values/strings.xml
+++ b/feature/sent/src/main/res/values/strings.xml
@@ -63,4 +63,5 @@
     <string name="sent_add_snackbar_relationship_validation">나와의 관계는 10글자까지만 입력 가능해요</string>
     <string name="sent_add_snackbar_category_validation">경조사는 10글자까지만 입력 가능해요</string>
     <string name="sent_add_snackbar_present_validation">선물은 30글자까지만 입력 가능해요</string>
+    <string name="sent_add_snackbar_memo_validation">메모는 30글자까지만 입력 가능해요</string>
 </resources>


### PR DESCRIPTION

## 🌱 Key changes
- 보내요 유효성 검사
    - [추가], [편집]에서 유효성 검사가 필요한 항목 처리
    - 유효하지 않은 입력 필터링 및 스낵바 노출
- 커스텀 항목 관련 문제 해결
    - [봉투 상세]에서 커스텀 카테고리와 관계가 '기타'로 표시되던 문제
    - [편집]에서 커스텀 관계가 초기화되지 않던 문제


## 📸 스크린샷

https://github.com/YAPP-Github/oksusu-susu-android/assets/69582122/88b01ff5-2bbc-4d5f-8aac-0f0d835a1860

https://github.com/YAPP-Github/oksusu-susu-android/assets/69582122/08d41c7b-28d5-4754-bb95-d204ff6b49c5


