### PR TITLE
Qa/18 received overflow

### DIFF
--- a/core/ui/src/main/java/com/susu/core/ui/Consts.kt
+++ b/core/ui/src/main/java/com/susu/core/ui/Consts.kt
@@ -26,7 +26,7 @@ val USER_INPUT_REGEX_LONG = Regex("[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣0-9]{0,30}")
 val USER_INPUT_REGEX_INCLUDE_NUMBER = Regex("[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣0-9]{0,10}")
 
 val USER_BIRTH_RANGE = 1930..currentDate.year
-const val MONEY_MAX_VALUE = 2_000_000_000L // TODO: 정책 확정 시 99억으로 변경
+const val MONEY_MAX_VALUE = 9_999_999_999L // TODO: 정책 확정 시 99억으로 변경
 
 const val INTENT_ACTION_DOWNLOAD_COMPLETE = "android.intent.action.DOWNLOAD_COMPLETE"
 const val PRIVACY_POLICY_URL = "https://sites.google.com/view/team-oksusu/%ED%99%88"

--- a/core/ui/src/main/java/com/susu/core/ui/Consts.kt
+++ b/core/ui/src/main/java/com/susu/core/ui/Consts.kt
@@ -26,7 +26,7 @@ val USER_INPUT_REGEX_LONG = Regex("[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣0-9]{0,30}")
 val USER_INPUT_REGEX_INCLUDE_NUMBER = Regex("[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣0-9]{0,10}")
 
 val USER_BIRTH_RANGE = 1930..currentDate.year
-const val MONEY_MAX_VALUE = 9_999_999_999L // TODO: 정책 확정 시 99억으로 변경
+const val MONEY_MAX_VALUE = 9_999_999_999L
 
 const val INTENT_ACTION_DOWNLOAD_COMPLETE = "android.intent.action.DOWNLOAD_COMPLETE"
 const val PRIVACY_POLICY_URL = "https://sites.google.com/view/team-oksusu/%ED%99%88"

--- a/core/ui/src/main/java/com/susu/core/ui/extension/String.kt
+++ b/core/ui/src/main/java/com/susu/core/ui/extension/String.kt
@@ -1,0 +1,5 @@
+package com.susu.core.ui.extension
+
+fun String.toPhoneNumber(): String {
+    return "${this.substring(0, 3)}-${this.substring(3, 7)}-${this.substring(7)}"
+}

--- a/core/ui/src/main/java/com/susu/core/ui/util/PhoneVisualTransformation.kt
+++ b/core/ui/src/main/java/com/susu/core/ui/util/PhoneVisualTransformation.kt
@@ -1,0 +1,35 @@
+package com.susu.core.ui.util
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+
+class PhoneVisualTransformation : VisualTransformation {
+    override fun filter(text: AnnotatedString): TransformedText {
+        val trimmed = if (text.text.length > 11) text.text.substring(0 until 11) else text.text
+        var out = ""
+        for (i in trimmed.indices) {
+            out += trimmed[i]
+            if (i == 2 || i == 6) out += "-"
+        }
+
+        return TransformedText(AnnotatedString(out), phoneOffsetTranslator)
+    }
+
+    private val phoneOffsetTranslator = object : OffsetMapping {
+        override fun originalToTransformed(offset: Int): Int {
+            if (offset <= 2) return offset
+            if (offset <= 6) return offset + 1
+            if (offset <= 11) return offset + 2
+            return 13
+        }
+
+        override fun transformedToOriginal(offset: Int): Int {
+            if (offset <= 3) return offset
+            if (offset <= 8) return offset - 1
+            if (offset <= 13) return offset - 2
+            return 11
+        }
+    }
+}

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/ReceivedEnvelopeAddScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/ReceivedEnvelopeAddScreen.kt
@@ -168,6 +168,7 @@ fun ReceivedEnvelopeAddScreen(
                 EnvelopeAddStep.PHONE -> PhoneContentRoute(
                     friendName = friendName,
                     updateParentPhone = updateParentPhoneNumber,
+                    onShowSnackbar = onShowSnackbar,
                 )
                 EnvelopeAddStep.MEMO -> MemoContentRoute(
                     updateParentMemo = updateParentMemo,

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/ReceivedEnvelopeAddScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/ReceivedEnvelopeAddScreen.kt
@@ -172,6 +172,7 @@ fun ReceivedEnvelopeAddScreen(
                 )
                 EnvelopeAddStep.MEMO -> MemoContentRoute(
                     updateParentMemo = updateParentMemo,
+                    onShowSnackbar = onShowSnackbar,
                 )
             }
         }

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/ReceivedEnvelopeAddScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/ReceivedEnvelopeAddScreen.kt
@@ -147,6 +147,7 @@ fun ReceivedEnvelopeAddScreen(
                 )
                 EnvelopeAddStep.RELATIONSHIP -> RelationShipContentRoute(
                     updateParentSelectedRelation = updateParentSelectedRelationShip,
+                    onShowSnackbar = onShowSnackbar,
                 )
                 EnvelopeAddStep.DATE -> DateContentRoute(
                     friendName = friendName,

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/ReceivedEnvelopeAddScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/ReceivedEnvelopeAddScreen.kt
@@ -163,6 +163,7 @@ fun ReceivedEnvelopeAddScreen(
 
                 EnvelopeAddStep.PRESENT -> PresentContentRoute(
                     updateParentPresent = updateParentPresent,
+                    onShowSnackbar = onShowSnackbar,
                 )
                 EnvelopeAddStep.PHONE -> PhoneContentRoute(
                     friendName = friendName,

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/ReceivedEnvelopeAddScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/ReceivedEnvelopeAddScreen.kt
@@ -143,6 +143,7 @@ fun ReceivedEnvelopeAddScreen(
                 EnvelopeAddStep.NAME -> NameContentRoute(
                     updateParentName = updateParentName,
                     updateParentFriendId = updateParentFriendId,
+                    onShowSnackbar = onShowSnackbar,
                 )
                 EnvelopeAddStep.RELATIONSHIP -> RelationShipContentRoute(
                     updateParentSelectedRelation = updateParentSelectedRelationShip,

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/ReceivedEnvelopeAddScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/ReceivedEnvelopeAddScreen.kt
@@ -86,6 +86,7 @@ fun ReceivedEnvelopeAddRoute(
         friendName = friendName,
         updateParentPhoneNumber = viewModel::updatePhoneNumber,
         updateParentMemo = viewModel::updateMemo,
+        onShowSnackbar = onShowSnackbar,
     )
 }
 
@@ -107,6 +108,7 @@ fun ReceivedEnvelopeAddScreen(
     friendName: String = "",
     updateParentPhoneNumber: (String?) -> Unit = {},
     updateParentMemo: (String?) -> Unit = {},
+    onShowSnackbar: (SnackbarToken) -> Unit = {},
 ) {
     Column(
         modifier = Modifier
@@ -135,6 +137,7 @@ fun ReceivedEnvelopeAddScreen(
             when (targetState) {
                 EnvelopeAddStep.MONEY -> MoneyContentRoute(
                     updateParentMoney = updateParentMoney,
+                    onShowSnackbar = onShowSnackbar,
                 )
 
                 EnvelopeAddStep.NAME -> NameContentRoute(

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/memo/MemoContent.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/memo/MemoContent.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -24,6 +25,7 @@ import com.susu.core.designsystem.component.textfield.SusuBasicTextField
 import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.Gray40
 import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.feature.received.R
 import kotlinx.coroutines.android.awaitFrame
@@ -33,10 +35,13 @@ import kotlinx.coroutines.launch
 fun MemoContentRoute(
     viewModel: MemoViewModel = hiltViewModel(),
     updateParentMemo: (String?) -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val focusRequester = remember { FocusRequester() }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             is MemoSideEffect.UpdateParentMemo -> updateParentMemo(sideEffect.memo)
@@ -44,6 +49,11 @@ fun MemoContentRoute(
                 awaitFrame()
                 focusRequester.requestFocus()
             }
+            MemoSideEffect.ShowNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.memo_content_snackbar_validation),
+                ),
+            )
         }
     }
 
@@ -91,6 +101,7 @@ fun MemoContent(
             placeholder = stringResource(R.string.memo_content_placeholder),
             placeholderColor = Gray40,
             modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),
+            maxLines = 5,
         )
         Spacer(modifier = Modifier.size(SusuTheme.spacing.spacing_xl))
     }

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/memo/MemoState.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/memo/MemoState.kt
@@ -10,4 +10,5 @@ data class MemoState(
 sealed interface MemoSideEffect : SideEffect {
     data class UpdateParentMemo(val memo: String?) : MemoSideEffect
     data object ShowKeyboard : MemoSideEffect
+    data object ShowNotValidSnackbar : MemoSideEffect
 }

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/memo/MemoViewModel.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/memo/MemoViewModel.kt
@@ -8,9 +8,16 @@ import javax.inject.Inject
 class MemoViewModel @Inject constructor() : BaseViewModel<MemoState, MemoSideEffect>(
     MemoState(),
 ) {
-    fun updateMemo(memo: String?) = intent {
-        postSideEffect(MemoSideEffect.UpdateParentMemo(memo))
-        copy(memo = memo ?: "")
+    fun updateMemo(memo: String?) {
+        if (memo != null && memo.length > 30) {
+            postSideEffect(MemoSideEffect.ShowNotValidSnackbar)
+            return
+        }
+
+        intent {
+            postSideEffect(MemoSideEffect.UpdateParentMemo(memo))
+            copy(memo = memo ?: "")
+        }
     }
 
     fun showKeyboardIfTextEmpty() {

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/money/MoneyContent.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/money/MoneyContent.kt
@@ -84,7 +84,7 @@ fun MoneyContent(
     uiState: MoneyState = MoneyState(),
     focusRequester: FocusRequester = remember { FocusRequester() },
     onTextChangeMoney: (String) -> Unit = {},
-    onClickMoneyButton: (Int) -> Unit = {},
+    onClickMoneyButton: (String, Int) -> Unit = { _, _ -> },
 ) {
     Column(
         modifier = Modifier
@@ -123,7 +123,7 @@ fun MoneyContent(
                     style = SmallButtonStyle.height32,
                     text = stringResource(id = com.susu.core.ui.R.string.money_unit_format, money.toMoneyFormat()),
                     onClick = {
-                        onClickMoneyButton(money)
+                        onClickMoneyButton(uiState.money, money)
                     },
                 )
             }

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/money/MoneyContent.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/money/MoneyContent.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -26,6 +27,7 @@ import com.susu.core.designsystem.component.button.SusuFilledButton
 import com.susu.core.designsystem.component.textfield.SusuPriceTextField
 import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.core.ui.extension.toMoneyFormat
 import com.susu.core.ui.moneyList
@@ -37,11 +39,12 @@ import kotlinx.coroutines.launch
 fun MoneyContentRoute(
     viewModel: MoneyViewModel = hiltViewModel(),
     updateParentMoney: (Long) -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
-
     val focusRequester = remember { FocusRequester() }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
 
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
@@ -50,6 +53,12 @@ fun MoneyContentRoute(
                 awaitFrame()
                 focusRequester.requestFocus()
             }
+
+            MoneySideEffect.ShowNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.money_content_snackbar_validation),
+                )
+            )
         }
     }
 

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/money/MoneyContent.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/money/MoneyContent.kt
@@ -84,7 +84,7 @@ fun MoneyContent(
     uiState: MoneyState = MoneyState(),
     focusRequester: FocusRequester = remember { FocusRequester() },
     onTextChangeMoney: (String) -> Unit = {},
-    onClickMoneyButton: (String, Int) -> Unit = { _, _ -> },
+    onClickMoneyButton: (Int) -> Unit = {},
 ) {
     Column(
         modifier = Modifier
@@ -123,7 +123,7 @@ fun MoneyContent(
                     style = SmallButtonStyle.height32,
                     text = stringResource(id = com.susu.core.ui.R.string.money_unit_format, money.toMoneyFormat()),
                     onClick = {
-                        onClickMoneyButton(uiState.money, money)
+                        onClickMoneyButton(money)
                     },
                 )
             }

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/money/MoneyContent.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/money/MoneyContent.kt
@@ -57,7 +57,7 @@ fun MoneyContentRoute(
             MoneySideEffect.ShowNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
                     message = context.getString(R.string.money_content_snackbar_validation),
-                )
+                ),
             )
         }
     }

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/money/MoneyContract.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/money/MoneyContract.kt
@@ -11,4 +11,6 @@ sealed interface MoneySideEffect : SideEffect {
     data class UpdateParentMoney(val money: Long) : MoneySideEffect
 
     data object ShowKeyboard : MoneySideEffect
+
+    data object ShowNotValidSnackbar : MoneySideEffect
 }

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/money/MoneyViewModel.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/money/MoneyViewModel.kt
@@ -20,13 +20,10 @@ class MoneyViewModel @Inject constructor() : BaseViewModel<MoneyState, MoneySide
         }
     }
 
-    fun addMoney(money: Int) = intent {
-        val currentMoney = this.money.toLongOrNull() ?: 0
-        val addedMoney = money + currentMoney
-        postSideEffect(MoneySideEffect.UpdateParentMoney(addedMoney))
-        copy(
-            money = addedMoney.toString(),
-        )
+    fun addMoney(textFieldMoney: String, buttonMoney: Int) {
+        val currentMoney = textFieldMoney.toLongOrNull() ?: 0
+        val addedMoney = currentMoney + buttonMoney
+        updateMoney(addedMoney.toString())
     }
 
     fun showKeyboardIfMoneyEmpty() {

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/money/MoneyViewModel.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/money/MoneyViewModel.kt
@@ -1,5 +1,6 @@
 package com.susu.feature.received.envelopeadd.content.money
 
+import com.susu.core.ui.MONEY_MAX_VALUE
 import com.susu.core.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -20,10 +21,21 @@ class MoneyViewModel @Inject constructor() : BaseViewModel<MoneyState, MoneySide
         }
     }
 
-    fun addMoney(textFieldMoney: String, buttonMoney: Int) {
-        val currentMoney = textFieldMoney.toLongOrNull() ?: 0
-        val addedMoney = currentMoney + buttonMoney
-        updateMoney(addedMoney.toString())
+    fun addMoney(money: Int) {
+        val currentMoney = currentState.money.toLongOrNull() ?: 0
+        val addedMoney = currentMoney + money
+
+        if (addedMoney > MONEY_MAX_VALUE) {
+            postSideEffect(MoneySideEffect.ShowNotValidSnackbar)
+            return
+        }
+        postSideEffect(MoneySideEffect.UpdateParentMoney(addedMoney))
+
+        intent {
+            copy(
+                money = addedMoney.toString(),
+            )
+        }
     }
 
     fun showKeyboardIfMoneyEmpty() {

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/money/MoneyViewModel.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/money/MoneyViewModel.kt
@@ -8,9 +8,16 @@ import javax.inject.Inject
 class MoneyViewModel @Inject constructor() : BaseViewModel<MoneyState, MoneySideEffect>(
     MoneyState(),
 ) {
-    fun updateMoney(money: String) = intent {
-        postSideEffect(MoneySideEffect.UpdateParentMoney(money.toLongOrNull() ?: 0))
-        copy(money = money)
+    fun updateMoney(money: String) {
+        if (money.length > 10) {
+            postSideEffect(MoneySideEffect.ShowNotValidSnackbar)
+            return
+        }
+
+        intent {
+            postSideEffect(MoneySideEffect.UpdateParentMoney(money.toLongOrNull() ?: 0))
+            copy(money = money)
+        }
     }
 
     fun addMoney(money: Int) = intent {

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/name/NameContent.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/name/NameContent.kt
@@ -65,7 +65,7 @@ fun NameContentRoute(
             NameSideEffect.ShowNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
                     message = context.getString(R.string.name_content_snackbar_validation),
-                )
+                ),
             )
         }
     }

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/name/NameContent.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/name/NameContent.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -29,6 +30,7 @@ import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.Gray40
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.model.FriendSearch
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.feature.received.R
 import com.susu.feature.received.envelopeadd.content.component.FriendListItem
@@ -43,11 +45,13 @@ fun NameContentRoute(
     viewModel: NameViewModel = hiltViewModel(),
     updateParentName: (String) -> Unit,
     updateParentFriendId: (Long?) -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val focusRequester = remember { FocusRequester() }
     val focusManager = LocalFocusManager.current
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
 
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
@@ -58,6 +62,11 @@ fun NameContentRoute(
                 awaitFrame()
                 focusRequester.requestFocus()
             }
+            NameSideEffect.ShowNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.name_content_snackbar_validation),
+                )
+            )
         }
     }
 

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/name/NameContract.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/name/NameContract.kt
@@ -17,4 +17,5 @@ sealed interface NameSideEffect : SideEffect {
     data class UpdateParentFriendId(val friendId: Long?) : NameSideEffect
     data object FocusClear : NameSideEffect
     data object ShowKeyboard : NameSideEffect
+    data object ShowNotValidSnackbar : NameSideEffect
 }

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/name/NameViewModel.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/name/NameViewModel.kt
@@ -2,6 +2,7 @@ package com.susu.feature.received.envelopeadd.content.name
 
 import androidx.lifecycle.viewModelScope
 import com.susu.core.model.FriendSearch
+import com.susu.core.ui.USER_INPUT_REGEX
 import com.susu.core.ui.base.BaseViewModel
 import com.susu.domain.usecase.friend.SearchFriendUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,16 +17,25 @@ class NameViewModel @Inject constructor(
 ) : BaseViewModel<NameState, NameSideEffect>(
     NameState(),
 ) {
-    fun updateName(name: String) = intent {
-        postSideEffect(
-            NameSideEffect.UpdateParentName(name),
-            NameSideEffect.UpdateParentFriendId(null),
-        )
-        copy(
-            name = name,
-            friendList = if (name.isEmpty()) persistentListOf() else friendList,
-            isSelectedFriend = false,
-        )
+    fun updateName(name: String) {
+        if (!USER_INPUT_REGEX.matches(name)) { // 한글, 영문 0~10 글자
+            if (name.length > 10) { // 길이 넘친 경우
+                postSideEffect(NameSideEffect.ShowNotValidSnackbar)
+            }
+            return // 특수문자는 입력 안 됨
+        }
+
+        intent {
+            postSideEffect(
+                NameSideEffect.UpdateParentName(name),
+                NameSideEffect.UpdateParentFriendId(null),
+            )
+            copy(
+                name = name,
+                friendList = if (name.isEmpty()) persistentListOf() else friendList,
+                isSelectedFriend = false,
+            )
+        }
     }
 
     fun selectFriend(friend: FriendSearch) = intent {

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/phone/PhoneContent.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/phone/PhoneContent.kt
@@ -27,6 +27,7 @@ import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.core.ui.util.AnnotatedText
+import com.susu.core.ui.util.PhoneVisualTransformation
 import com.susu.feature.received.R
 import kotlinx.coroutines.android.awaitFrame
 import kotlinx.coroutines.launch
@@ -105,6 +106,7 @@ fun PhoneContent(
             placeholderColor = Gray40,
             modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            visualTransformation = PhoneVisualTransformation(),
         )
         Spacer(modifier = Modifier.size(SusuTheme.spacing.spacing_xl))
     }

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/phone/PhoneContent.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/phone/PhoneContent.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
@@ -23,6 +24,7 @@ import com.susu.core.designsystem.component.textfield.SusuBasicTextField
 import com.susu.core.designsystem.theme.Gray40
 import com.susu.core.designsystem.theme.Gray60
 import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.core.ui.util.AnnotatedText
 import com.susu.feature.received.R
@@ -34,10 +36,13 @@ fun PhoneContentRoute(
     viewModel: PhoneViewModel = hiltViewModel(),
     friendName: String,
     updateParentPhone: (String?) -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val focusRequester = remember { FocusRequester() }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             is PhoneSideEffect.UpdateParentPhone -> updateParentPhone(sideEffect.phone)
@@ -45,6 +50,11 @@ fun PhoneContentRoute(
                 awaitFrame()
                 focusRequester.requestFocus()
             }
+            PhoneSideEffect.ShowNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.phone_content_snackbar_validation),
+                ),
+            )
         }
     }
 

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/phone/PhoneContract.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/phone/PhoneContract.kt
@@ -11,4 +11,5 @@ data class PhoneState(
 sealed interface PhoneSideEffect : SideEffect {
     data class UpdateParentPhone(val phone: String?) : PhoneSideEffect
     data object ShowKeyboard : PhoneSideEffect
+    data object ShowNotValidSnackbar : PhoneSideEffect
 }

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/phone/PhoneViewModel.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/phone/PhoneViewModel.kt
@@ -9,9 +9,16 @@ class PhoneViewModel @Inject constructor() : BaseViewModel<PhoneState, PhoneSide
     PhoneState(),
 ) {
     fun updateName(name: String) = intent { copy(name = name) }
-    fun updatePhone(phone: String?) = intent {
-        postSideEffect(PhoneSideEffect.UpdateParentPhone(phone))
-        copy(phone = phone ?: "")
+    fun updatePhone(phone: String?) {
+        if (phone != null && phone.length > 11) {
+            postSideEffect(PhoneSideEffect.ShowNotValidSnackbar)
+            return
+        }
+
+        intent {
+            postSideEffect(PhoneSideEffect.UpdateParentPhone(phone))
+            copy(phone = phone ?: "")
+        }
     }
 
     fun showKeyboardIfTextEmpty() {

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/present/PresentContent.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/present/PresentContent.kt
@@ -51,7 +51,7 @@ fun PresentContentRoute(
             PresentSideEffect.ShowNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
                     message = context.getString(R.string.present_content_snackbar_validation),
-                )
+                ),
             )
         }
     }

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/present/PresentContent.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/present/PresentContent.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -22,6 +23,7 @@ import com.susu.core.designsystem.component.textfield.SusuBasicTextField
 import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.Gray40
 import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.feature.received.R
 import kotlinx.coroutines.android.awaitFrame
@@ -31,10 +33,13 @@ import kotlinx.coroutines.launch
 fun PresentContentRoute(
     viewModel: PresentViewModel = hiltViewModel(),
     updateParentPresent: (String?) -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val focusRequester = remember { FocusRequester() }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             is PresentSideEffect.UpdateParentPresent -> updateParentPresent(sideEffect.present)
@@ -42,6 +47,12 @@ fun PresentContentRoute(
                 awaitFrame()
                 focusRequester.requestFocus()
             }
+
+            PresentSideEffect.ShowNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.present_content_snackbar_validation),
+                )
+            )
         }
     }
 
@@ -89,6 +100,7 @@ fun PresentContent(
             placeholder = stringResource(R.string.present_content_placeholder),
             placeholderColor = Gray40,
             modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),
+            maxLines = 5,
         )
         Spacer(modifier = Modifier.size(SusuTheme.spacing.spacing_xl))
     }

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/present/PresentContract.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/present/PresentContract.kt
@@ -10,4 +10,5 @@ data class PresentState(
 sealed interface PresentSideEffect : SideEffect {
     data class UpdateParentPresent(val present: String?) : PresentSideEffect
     data object ShowKeyboard : PresentSideEffect
+    data object ShowNotValidSnackbar : PresentSideEffect
 }

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/present/PresentViewModel.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/present/PresentViewModel.kt
@@ -1,6 +1,7 @@
 package com.susu.feature.received.envelopeadd.content.present
 
 import androidx.lifecycle.viewModelScope
+import com.susu.core.ui.USER_INPUT_REGEX_LONG
 import com.susu.core.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
@@ -11,9 +12,18 @@ import javax.inject.Inject
 class PresentViewModel @Inject constructor() : BaseViewModel<PresentState, PresentSideEffect>(
     PresentState(),
 ) {
-    fun updatePresent(present: String?) = intent {
-        postSideEffect(PresentSideEffect.UpdateParentPresent(present))
-        copy(present = present ?: "")
+    fun updatePresent(present: String?) {
+        if (present != null && !USER_INPUT_REGEX_LONG.matches(present)) {
+            if (present.length > 30) {
+                postSideEffect(PresentSideEffect.ShowNotValidSnackbar)
+            }
+            return
+        }
+
+        intent {
+            postSideEffect(PresentSideEffect.UpdateParentPresent(present))
+            copy(present = present ?: "")
+        }
     }
 
     fun showKeyboardIfTextEmpty() = viewModelScope.launch {

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/relationship/RelationShipContent.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/relationship/RelationShipContent.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -32,6 +33,7 @@ import com.susu.core.designsystem.component.textfieldbutton.style.MediumTextFiel
 import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.model.Relationship
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.feature.received.R
 import kotlinx.coroutines.android.awaitFrame
@@ -41,10 +43,13 @@ import kotlinx.coroutines.launch
 fun RelationShipContentRoute(
     viewModel: RelationShipViewModel = hiltViewModel(),
     updateParentSelectedRelation: (Relationship?) -> Unit = {},
+    onShowSnackbar: (SnackbarToken) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val focusRequester = remember { FocusRequester() }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             is RelationShipSideEffect.UpdateParentSelectedRelationShip -> {
@@ -55,6 +60,12 @@ fun RelationShipContentRoute(
                 awaitFrame()
                 focusRequester.requestFocus()
             }
+
+            RelationShipSideEffect.ShowNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.relationship_content_snackbar_validation),
+                )
+            )
         }
     }
 

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/relationship/RelationShipContent.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/relationship/RelationShipContent.kt
@@ -64,7 +64,7 @@ fun RelationShipContentRoute(
             RelationShipSideEffect.ShowNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
                     message = context.getString(R.string.relationship_content_snackbar_validation),
-                )
+                ),
             )
         }
     }

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/relationship/RelationShipContract.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/relationship/RelationShipContract.kt
@@ -19,4 +19,5 @@ data class RelationShipState(
 sealed interface RelationShipSideEffect : SideEffect {
     data object FocusCustomRelationShip : RelationShipSideEffect
     data class UpdateParentSelectedRelationShip(val relationShip: Relationship?) : RelationShipSideEffect
+    data object ShowNotValidSnackbar : RelationShipSideEffect
 }

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/relationship/RelationShipViewModel.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/relationship/RelationShipViewModel.kt
@@ -2,8 +2,10 @@ package com.susu.feature.received.envelopeadd.content.relationship
 
 import androidx.lifecycle.viewModelScope
 import com.susu.core.model.Relationship
+import com.susu.core.ui.USER_INPUT_REGEX
 import com.susu.core.ui.base.BaseViewModel
 import com.susu.domain.usecase.envelope.GetRelationShipConfigListUseCase
+import com.susu.feature.received.envelopeadd.content.name.NameSideEffect
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
@@ -51,11 +53,20 @@ class RelationShipViewModel @Inject constructor(
         copy(selectedRelationship = customRelationship)
     }
 
-    fun updateCustomRelationShipText(text: String) = intent {
-        copy(
-            selectedRelationship = customRelationship.copy(customRelation = text),
-            customRelationship = customRelationship.copy(customRelation = text),
-        )
+    fun updateCustomRelationShipText(text: String) {
+        if (!USER_INPUT_REGEX.matches(text)) { // 한글, 영문 0~10 글자
+            if (text.length > 10) { // 길이 넘친 경우
+                postSideEffect(RelationShipSideEffect.ShowNotValidSnackbar)
+            }
+            return // 특수문자는 입력 안 됨
+        }
+
+        intent {
+            copy(
+                selectedRelationship = customRelationship.copy(customRelation = text),
+                customRelationship = customRelationship.copy(customRelation = text),
+            )
+        }
     }
 
     fun showCustomRelationShipTextField() = intent {

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/relationship/RelationShipViewModel.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeadd/content/relationship/RelationShipViewModel.kt
@@ -5,7 +5,6 @@ import com.susu.core.model.Relationship
 import com.susu.core.ui.USER_INPUT_REGEX
 import com.susu.core.ui.base.BaseViewModel
 import com.susu.domain.usecase.envelope.GetRelationShipConfigListUseCase
-import com.susu.feature.received.envelopeadd.content.name.NameSideEffect
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch

--- a/feature/received/src/main/java/com/susu/feature/received/envelopedetail/ReceivedEnvelopeDetailScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopedetail/ReceivedEnvelopeDetailScreen.kt
@@ -175,8 +175,11 @@ fun ReceivedEnvelopeDetailScreen(
                     )
                     DetailItem(
                         categoryText = stringResource(id = com.susu.core.ui.R.string.word_phone_number),
-                        contentText = if (uiState.envelope.friend.phoneNumber.isNullOrEmpty()) "" else
-                            uiState.envelope.friend.phoneNumber.toPhoneNumber(),
+                        contentText = if (uiState.envelope.friend.phoneNumber.isNullOrEmpty()) {
+                            ""
+                        } else {
+                            uiState.envelope.friend.phoneNumber.toPhoneNumber()
+                        },
                         isEmptyContent = uiState.envelope.friend.phoneNumber.isEmpty(),
                     )
                     DetailItem(

--- a/feature/received/src/main/java/com/susu/feature/received/envelopedetail/ReceivedEnvelopeDetailScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopedetail/ReceivedEnvelopeDetailScreen.kt
@@ -32,6 +32,7 @@ import com.susu.core.ui.DialogToken
 import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.core.ui.extension.toMoneyFormat
+import com.susu.core.ui.extension.toPhoneNumber
 import com.susu.core.ui.util.to_yyyy_korYear_M_korMonth_d_korDay
 import com.susu.feature.received.R
 import com.susu.feature.received.envelopedetail.component.DetailItem
@@ -174,7 +175,8 @@ fun ReceivedEnvelopeDetailScreen(
                     )
                     DetailItem(
                         categoryText = stringResource(id = com.susu.core.ui.R.string.word_phone_number),
-                        contentText = uiState.envelope.friend.phoneNumber,
+                        contentText = if (uiState.envelope.friend.phoneNumber.isNullOrEmpty()) "" else
+                            uiState.envelope.friend.phoneNumber.toPhoneNumber(),
                         isEmptyContent = uiState.envelope.friend.phoneNumber.isEmpty(),
                     )
                     DetailItem(

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeedit/ReceivedEnvelopeEditContract.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeedit/ReceivedEnvelopeEditContract.kt
@@ -25,4 +25,10 @@ sealed interface ReceivedEnvelopeEditSideEffect : SideEffect {
     data object FocusCustomRelation : ReceivedEnvelopeEditSideEffect
     data object PopBackStack : ReceivedEnvelopeEditSideEffect
     data class HandleException(val throwable: Throwable, val retry: () -> Unit) : ReceivedEnvelopeEditSideEffect
+    data object ShowMoneyNotValidSnackbar : ReceivedEnvelopeEditSideEffect
+    data object ShowNameNotValidSnackbar : ReceivedEnvelopeEditSideEffect
+    data object ShowRelationshipNotValidSnackbar : ReceivedEnvelopeEditSideEffect
+    data object ShowPresentNotValidSnackbar : ReceivedEnvelopeEditSideEffect
+    data object ShowPhoneNotValidSnackbar : ReceivedEnvelopeEditSideEffect
+    data object ShowMemoNotValidSnackbar : ReceivedEnvelopeEditSideEffect
 }

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeedit/ReceivedEnvelopeEditScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeedit/ReceivedEnvelopeEditScreen.kt
@@ -51,6 +51,7 @@ import com.susu.core.model.Relationship
 import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.core.ui.extension.susuClickable
+import com.susu.core.ui.util.PhoneVisualTransformation
 import com.susu.feature.received.R
 import com.susu.feature.received.envelopeedit.component.EditDetailItem
 import kotlinx.coroutines.android.awaitFrame
@@ -298,6 +299,7 @@ fun ReceivedEnvelopeEditScreen(
                         textStyle = SusuTheme.typography.title_s,
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                         modifier = Modifier.fillMaxWidth(),
+                        visualTransformation = PhoneVisualTransformation(),
                     )
                 }
                 EditDetailItem(

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeedit/ReceivedEnvelopeEditScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeedit/ReceivedEnvelopeEditScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
@@ -47,6 +48,7 @@ import com.susu.core.designsystem.theme.Gray40
 import com.susu.core.designsystem.theme.Gray70
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.model.Relationship
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.core.ui.extension.susuClickable
 import com.susu.feature.received.R
@@ -59,11 +61,12 @@ fun ReceivedEnvelopeEditRoute(
     viewModel: ReceivedEnvelopeEditViewModel = hiltViewModel(),
     popBackStack: () -> Unit,
     handleException: (Throwable, () -> Unit) -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
-
     val focusRequester = remember { FocusRequester() }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
 
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
@@ -71,12 +74,41 @@ fun ReceivedEnvelopeEditRoute(
                 sideEffect.throwable,
                 sideEffect.retry,
             )
-
             ReceivedEnvelopeEditSideEffect.PopBackStack -> popBackStack()
             ReceivedEnvelopeEditSideEffect.FocusCustomRelation -> scope.launch {
                 awaitFrame()
                 focusRequester.requestFocus()
             }
+            ReceivedEnvelopeEditSideEffect.ShowMoneyNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.money_content_snackbar_validation),
+                ),
+            )
+            ReceivedEnvelopeEditSideEffect.ShowNameNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.name_content_snackbar_validation),
+                ),
+            )
+            ReceivedEnvelopeEditSideEffect.ShowRelationshipNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.relationship_content_snackbar_validation),
+                ),
+            )
+            ReceivedEnvelopeEditSideEffect.ShowPresentNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.present_content_snackbar_validation),
+                ),
+            )
+            ReceivedEnvelopeEditSideEffect.ShowPhoneNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.phone_content_snackbar_validation),
+                ),
+            )
+            ReceivedEnvelopeEditSideEffect.ShowMemoNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.memo_content_snackbar_validation),
+                ),
+            )
         }
     }
 
@@ -250,6 +282,7 @@ fun ReceivedEnvelopeEditScreen(
                         placeholderColor = Gray30,
                         textStyle = SusuTheme.typography.title_s,
                         modifier = Modifier.fillMaxWidth(),
+                        maxLines = 5,
                     )
                 }
                 EditDetailItem(
@@ -279,6 +312,7 @@ fun ReceivedEnvelopeEditScreen(
                         placeholderColor = Gray30,
                         textStyle = SusuTheme.typography.title_s,
                         modifier = Modifier.fillMaxWidth(),
+                        maxLines = 5,
                     )
                 }
                 Spacer(modifier = Modifier.height(SusuTheme.spacing.spacing_xxxl))

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeedit/ReceivedEnvelopeEditViewModel.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeedit/ReceivedEnvelopeEditViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import com.susu.core.model.Envelope
 import com.susu.core.model.Ledger
 import com.susu.core.model.Relationship
-import com.susu.core.ui.MONEY_MAX_VALUE
 import com.susu.core.ui.USER_INPUT_REGEX
 import com.susu.core.ui.USER_INPUT_REGEX_INCLUDE_NUMBER
 import com.susu.core.ui.USER_INPUT_REGEX_LONG
@@ -13,7 +12,6 @@ import com.susu.core.ui.base.BaseViewModel
 import com.susu.core.ui.extension.decodeFromUri
 import com.susu.domain.usecase.envelope.EditReceivedEnvelopeUseCase
 import com.susu.domain.usecase.envelope.GetRelationShipConfigListUseCase
-import com.susu.feature.received.envelopeadd.content.money.MoneySideEffect
 import com.susu.feature.received.navigation.ReceivedRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList

--- a/feature/received/src/main/java/com/susu/feature/received/envelopeedit/ReceivedEnvelopeEditViewModel.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/envelopeedit/ReceivedEnvelopeEditViewModel.kt
@@ -5,10 +5,15 @@ import androidx.lifecycle.viewModelScope
 import com.susu.core.model.Envelope
 import com.susu.core.model.Ledger
 import com.susu.core.model.Relationship
+import com.susu.core.ui.MONEY_MAX_VALUE
+import com.susu.core.ui.USER_INPUT_REGEX
+import com.susu.core.ui.USER_INPUT_REGEX_INCLUDE_NUMBER
+import com.susu.core.ui.USER_INPUT_REGEX_LONG
 import com.susu.core.ui.base.BaseViewModel
 import com.susu.core.ui.extension.decodeFromUri
 import com.susu.domain.usecase.envelope.EditReceivedEnvelopeUseCase
 import com.susu.domain.usecase.envelope.GetRelationShipConfigListUseCase
+import com.susu.feature.received.envelopeadd.content.money.MoneySideEffect
 import com.susu.feature.received.navigation.ReceivedRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
@@ -87,16 +92,32 @@ class ReceivedEnvelopeEditViewModel @Inject constructor(
 
     fun popBackStack() = postSideEffect(ReceivedEnvelopeEditSideEffect.PopBackStack)
 
-    fun updateMoney(money: String) = intent {
-        copy(
-            envelope = envelope.copy(amount = money.toLongOrNull() ?: 0L),
-        )
+    fun updateMoney(money: String) {
+        if (money.length > 10) {
+            postSideEffect(ReceivedEnvelopeEditSideEffect.ShowMoneyNotValidSnackbar)
+            return
+        }
+
+        intent {
+            copy(
+                envelope = envelope.copy(amount = money.toLongOrNull() ?: 0L),
+            )
+        }
     }
 
-    fun updateName(name: String) = intent {
-        copy(
-            envelope = envelope.copy(friend = envelope.friend.copy(name = name)),
-        )
+    fun updateName(name: String) {
+        if (!USER_INPUT_REGEX.matches(name)) {
+            if (name.length > 10) {
+                postSideEffect(ReceivedEnvelopeEditSideEffect.ShowNameNotValidSnackbar)
+            }
+            return
+        }
+
+        intent {
+            copy(
+                envelope = envelope.copy(friend = envelope.friend.copy(name = name)),
+            )
+        }
     }
 
     fun updateRelation(relationship: Relationship) = intent {
@@ -105,17 +126,26 @@ class ReceivedEnvelopeEditViewModel @Inject constructor(
         )
     }
 
-    fun updateCustomRelation(customRelation: String?) = intent {
-        copy(
-            envelope = envelope.copy(relationship = envelope.relationship.copy(customRelation = customRelation)),
-            relationshipConfig = relationshipConfig.map {
-                if (it.id == envelope.relationship.id) {
-                    it.copy(customRelation = customRelation)
-                } else {
-                    it
-                }
-            }.toPersistentList(),
-        )
+    fun updateCustomRelation(customRelation: String?) {
+        if (customRelation != null && !USER_INPUT_REGEX_INCLUDE_NUMBER.matches(customRelation)) {
+            if (customRelation.length > 10) {
+                postSideEffect(ReceivedEnvelopeEditSideEffect.ShowRelationshipNotValidSnackbar)
+            }
+            return
+        }
+
+        intent {
+            copy(
+                envelope = envelope.copy(relationship = envelope.relationship.copy(customRelation = customRelation)),
+                relationshipConfig = relationshipConfig.map {
+                    if (it.id == envelope.relationship.id) {
+                        it.copy(customRelation = customRelation)
+                    } else {
+                        it
+                    }
+                }.toPersistentList(),
+            )
+        }
     }
 
     fun closeCustomRelation() = intent {
@@ -164,30 +194,53 @@ class ReceivedEnvelopeEditViewModel @Inject constructor(
         )
     }
 
-    fun updateGift(gift: String) = intent {
-        copy(
-            envelope = envelope.copy(
-                gift = gift.ifEmpty { null },
-            ),
-        )
-    }
+    fun updateGift(gift: String) {
+        if (gift != null && !USER_INPUT_REGEX_LONG.matches(gift)) {
+            if (gift.length > 30) {
+                postSideEffect(ReceivedEnvelopeEditSideEffect.ShowPresentNotValidSnackbar)
+            }
+            return
+        }
 
-    fun updatePhoneNumber(phoneNumber: String) = intent {
-        copy(
-            envelope = envelope.copy(
-                friend = envelope.friend.copy(
-                    phoneNumber = phoneNumber,
+        intent {
+            copy(
+                envelope = envelope.copy(
+                    gift = gift.ifEmpty { null },
                 ),
-            ),
-        )
+            )
+        }
     }
 
-    fun updateMemo(memo: String) = intent {
-        copy(
-            envelope = envelope.copy(
-                memo = memo.ifEmpty { null },
-            ),
-        )
+    fun updatePhoneNumber(phoneNumber: String) {
+        if (phoneNumber != null && phoneNumber.length > 11) {
+            postSideEffect(ReceivedEnvelopeEditSideEffect.ShowPhoneNotValidSnackbar)
+            return
+        }
+
+        intent {
+            copy(
+                envelope = envelope.copy(
+                    friend = envelope.friend.copy(
+                        phoneNumber = phoneNumber,
+                    ),
+                ),
+            )
+        }
+    }
+
+    fun updateMemo(memo: String) {
+        if (memo != null && memo.length > 30) {
+            postSideEffect(ReceivedEnvelopeEditSideEffect.ShowMemoNotValidSnackbar)
+            return
+        }
+
+        intent {
+            copy(
+                envelope = envelope.copy(
+                    memo = memo.ifEmpty { null },
+                ),
+            )
+        }
     }
 
     fun hideDateBottomSheet(year: Int, month: Int, day: Int) = intent {

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeradd/LedgerAddScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeradd/LedgerAddScreen.kt
@@ -28,6 +28,7 @@ import com.susu.core.designsystem.component.screen.LoadingScreen
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.model.Category
 import com.susu.core.ui.R
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.core.ui.extension.susuDefaultAnimatedContentTransitionSpec
 import com.susu.feature.received.ledgeradd.content.category.CategoryContentRoute
@@ -40,6 +41,7 @@ fun LedgerAddRoute(
     viewModel: LedgerAddViewModel = hiltViewModel(),
     popBackStack: () -> Unit,
     popBackStackWithLedger: (String) -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
     handleException: (Throwable, () -> Unit) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
@@ -82,6 +84,7 @@ fun LedgerAddRoute(
         updateParentDate = { startAt, endAt ->
             viewModel.updateDate(startAt, endAt)
         },
+        onShowSnackbar = onShowSnackbar
     )
 }
 
@@ -95,6 +98,7 @@ fun LedgerAddScreen(
     dateContentCategory: Category? = Category(),
     dateContentName: String = "",
     updateParentDate: (LocalDateTime?, LocalDateTime?) -> Unit = { _, _ -> },
+    onShowSnackbar: (SnackbarToken) -> Unit = {},
 ) {
     Column(
         modifier = Modifier
@@ -122,6 +126,7 @@ fun LedgerAddScreen(
             when (targetState) {
                 LedgerAddStep.CATEGORY -> CategoryContentRoute(
                     updateParentSelectedCategory = updateParentSelectedCategory,
+                    onShowSnackbar = onShowSnackbar,
                 )
 
                 LedgerAddStep.NAME -> NameContentRoute(

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeradd/LedgerAddScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeradd/LedgerAddScreen.kt
@@ -131,6 +131,7 @@ fun LedgerAddScreen(
 
                 LedgerAddStep.NAME -> NameContentRoute(
                     updateParentName = updateParentName,
+                    onShowSnackbar = onShowSnackbar,
                 )
 
                 LedgerAddStep.DATE -> DateContentRoute(

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeradd/LedgerAddScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeradd/LedgerAddScreen.kt
@@ -84,7 +84,7 @@ fun LedgerAddRoute(
         updateParentDate = { startAt, endAt ->
             viewModel.updateDate(startAt, endAt)
         },
-        onShowSnackbar = onShowSnackbar
+        onShowSnackbar = onShowSnackbar,
     )
 }
 

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/category/CategoryContent.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/category/CategoryContent.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -31,6 +32,7 @@ import com.susu.core.designsystem.component.textfieldbutton.TextFieldButtonColor
 import com.susu.core.designsystem.component.textfieldbutton.style.MediumTextFieldButtonStyle
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.model.Category
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.feature.received.R
 import kotlinx.coroutines.android.awaitFrame
@@ -40,10 +42,13 @@ import kotlinx.coroutines.launch
 fun CategoryContentRoute(
     viewModel: CategoryViewModel = hiltViewModel(),
     updateParentSelectedCategory: (Category?) -> Unit = {},
+    onShowSnackbar: (SnackbarToken) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val focusRequester = remember { FocusRequester() }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             is CategorySideEffect.UpdateParentSelectedCategory -> {
@@ -54,6 +59,12 @@ fun CategoryContentRoute(
                 awaitFrame()
                 focusRequester.requestFocus()
             }
+
+            CategorySideEffect.ShowNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.ledger_snackbar_category_validation),
+                )
+            )
         }
     }
 

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/category/CategoryContent.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/category/CategoryContent.kt
@@ -63,7 +63,7 @@ fun CategoryContentRoute(
             CategorySideEffect.ShowNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
                     message = context.getString(R.string.ledger_snackbar_category_validation),
-                )
+                ),
             )
         }
     }

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/category/CategoryContract.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/category/CategoryContract.kt
@@ -19,4 +19,5 @@ data class CategoryState(
 sealed interface CategorySideEffect : SideEffect {
     data object FocusCustomCategory : CategorySideEffect
     data class UpdateParentSelectedCategory(val category: Category?) : CategorySideEffect
+    data object ShowNotValidSnackbar : CategorySideEffect
 }

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/category/CategoryViewModel.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/category/CategoryViewModel.kt
@@ -2,6 +2,7 @@ package com.susu.feature.received.ledgeradd.content.category
 
 import androidx.lifecycle.viewModelScope
 import com.susu.core.model.Category
+import com.susu.core.ui.USER_INPUT_REGEX_INCLUDE_NUMBER
 import com.susu.core.ui.base.BaseViewModel
 import com.susu.domain.usecase.categoryconfig.GetCategoryConfigUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -46,11 +47,20 @@ class CategoryViewModel @Inject constructor(
         copy(selectedCategory = customCategory)
     }
 
-    fun updateCustomCategoryText(text: String) = intent {
-        copy(
-            selectedCategory = customCategory.copy(customCategory = text),
-            customCategory = customCategory.copy(customCategory = text),
-        )
+    fun updateCustomCategoryText(text: String) {
+        if (!USER_INPUT_REGEX_INCLUDE_NUMBER.matches(text)) { // 한글, 영문 0~10 글자
+            if (text.length > 10) { // 길이 넘친 경우
+                postSideEffect(CategorySideEffect.ShowNotValidSnackbar)
+            }
+            return // 특수문자는 입력 안 됨
+        }
+
+        intent {
+            copy(
+                selectedCategory = customCategory.copy(customCategory = text),
+                customCategory = customCategory.copy(customCategory = text),
+            )
+        }
     }
 
     fun showCustomCategoryTextField() = intent {

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/name/NameContent.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/name/NameContent.kt
@@ -13,12 +13,14 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.susu.core.designsystem.component.textfield.SusuBasicTextField
 import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.feature.received.R
 import kotlinx.coroutines.android.awaitFrame
@@ -28,10 +30,13 @@ import kotlinx.coroutines.launch
 fun NameContentRoute(
     viewModel: NameViewModel = hiltViewModel(),
     updateParentName: (String) -> Unit = {},
+    onShowSnackbar: (SnackbarToken) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val focusRequester = remember { FocusRequester() }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             is NameSideEffect.UpdateParentName -> {
@@ -42,6 +47,12 @@ fun NameContentRoute(
                 awaitFrame()
                 focusRequester.requestFocus()
             }
+
+            NameSideEffect.ShowNotValidSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.ledger_snackbar_category_name_validation),
+                )
+            )
         }
     }
 

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/name/NameContent.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/name/NameContent.kt
@@ -51,7 +51,7 @@ fun NameContentRoute(
             NameSideEffect.ShowNotValidSnackbar -> onShowSnackbar(
                 SnackbarToken(
                     message = context.getString(R.string.ledger_snackbar_category_name_validation),
-                )
+                ),
             )
         }
     }

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/name/NameContract.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/name/NameContract.kt
@@ -10,4 +10,5 @@ data class NameState(
 sealed interface NameSideEffect : SideEffect {
     data class UpdateParentName(val name: String) : NameSideEffect
     data object ShowKeyboard : NameSideEffect
+    data object ShowNotValidSnackbar : NameSideEffect
 }

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/name/NameViewModel.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeradd/content/name/NameViewModel.kt
@@ -1,6 +1,7 @@
 package com.susu.feature.received.ledgeradd.content.name
 
 import androidx.lifecycle.viewModelScope
+import com.susu.core.ui.USER_INPUT_REGEX_INCLUDE_NUMBER
 import com.susu.core.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
@@ -11,9 +12,18 @@ import javax.inject.Inject
 class NameViewModel @Inject constructor() : BaseViewModel<NameState, NameSideEffect>(
     NameState(),
 ) {
-    fun updateName(name: String) = intent {
-        postSideEffect(NameSideEffect.UpdateParentName(name))
-        copy(name = name)
+    fun updateName(name: String) {
+        if (!USER_INPUT_REGEX_INCLUDE_NUMBER.matches(name)) { // 한글, 영문 0~10 글자
+            if (name.length > 10) { // 길이 넘친 경우
+                postSideEffect(NameSideEffect.ShowNotValidSnackbar)
+            }
+            return // 특수문자는 입력 안 됨
+        }
+
+        intent {
+            postSideEffect(NameSideEffect.UpdateParentName(name))
+            copy(name = name)
+        }
     }
 
     fun showKeyboardIfTextEmpty() = viewModelScope.launch {

--- a/feature/received/src/main/java/com/susu/feature/received/ledgerdetail/component/LedgerDetailEnvelopeContainer.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgerdetail/component/LedgerDetailEnvelopeContainer.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
@@ -18,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.susu.core.designsystem.component.badge.BadgeColor
@@ -86,8 +88,11 @@ fun LedgerDetailEnvelopeContainer(
             Text(
                 text = envelope.friend.name,
                 style = SusuTheme.typography.title_xs,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f, false),
             )
-            Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = Modifier.size(SusuTheme.spacing.spacing_s))
             Text(
                 text = stringResource(id = R.string.money_unit_format, envelope.envelope.amount.toInt().toMoneyFormat()),
                 style = SusuTheme.typography.title_m,

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeredit/LedgerEditContract.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeredit/LedgerEditContract.kt
@@ -35,4 +35,6 @@ data class LedgerEditState(
 sealed interface LedgerEditSideEffect : SideEffect {
     data object PopBackStack : LedgerEditSideEffect
     data object FocusCustomCategory : LedgerEditSideEffect
+    data object ShowNotValidSnackbarName : LedgerEditSideEffect
+    data object ShowNotValidSnackbarCategory : LedgerEditSideEffect
 }

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeredit/LedgerEditScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeredit/LedgerEditScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -50,6 +51,7 @@ import com.susu.core.designsystem.theme.Gray30
 import com.susu.core.designsystem.theme.Gray80
 import com.susu.core.designsystem.theme.Orange60
 import com.susu.core.designsystem.theme.SusuTheme
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.core.ui.extension.susuClickable
 import com.susu.core.ui.util.AnnotatedText
@@ -63,11 +65,13 @@ import kotlinx.coroutines.launch
 fun LedgerEditRoute(
     viewModel: LedgerEditViewModel = hiltViewModel(),
     popBackStack: () -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
 
     val focusRequester = remember { FocusRequester() }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
 
     viewModel.sideEffect.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
@@ -76,6 +80,16 @@ fun LedgerEditRoute(
                 awaitFrame()
                 focusRequester.requestFocus()
             }
+            LedgerEditSideEffect.ShowNotValidSnackbarName -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.ledger_snackbar_category_name_validation),
+                )
+            )
+            LedgerEditSideEffect.ShowNotValidSnackbarCategory -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.ledger_snackbar_category_validation)
+                )
+            )
         }
     }
 

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeredit/LedgerEditScreen.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeredit/LedgerEditScreen.kt
@@ -83,12 +83,12 @@ fun LedgerEditRoute(
             LedgerEditSideEffect.ShowNotValidSnackbarName -> onShowSnackbar(
                 SnackbarToken(
                     message = context.getString(R.string.ledger_snackbar_category_name_validation),
-                )
+                ),
             )
             LedgerEditSideEffect.ShowNotValidSnackbarCategory -> onShowSnackbar(
                 SnackbarToken(
-                    message = context.getString(R.string.ledger_snackbar_category_validation)
-                )
+                    message = context.getString(R.string.ledger_snackbar_category_validation),
+                ),
             )
         }
     }

--- a/feature/received/src/main/java/com/susu/feature/received/ledgeredit/LedgerEditViewModel.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgeredit/LedgerEditViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.susu.core.model.Category
 import com.susu.core.model.Ledger
+import com.susu.core.ui.USER_INPUT_REGEX
 import com.susu.core.ui.base.BaseViewModel
 import com.susu.core.ui.extension.decodeFromUri
 import com.susu.domain.usecase.categoryconfig.GetCategoryConfigUseCase
@@ -87,7 +88,16 @@ class LedgerEditViewModel @Inject constructor(
         copy(selectedCategoryId = categoryId)
     }
 
-    fun updateName(name: String) = intent { copy(name = name) }
+    fun updateName(name: String) {
+        if (!USER_INPUT_REGEX.matches(name)) { // 한글, 영문 0~10 글자
+            if (name.length > 10) { // 길이 넘친 경우
+                postSideEffect(LedgerEditSideEffect.ShowNotValidSnackbarName)
+            }
+            return // 특수문자는 입력 안 됨
+        }
+
+        intent { copy(name = name) }
+    }
 
     fun toggleCustomCategorySaved() = intent {
         copy(
@@ -95,10 +105,19 @@ class LedgerEditViewModel @Inject constructor(
         )
     }
 
-    fun updateCustomCategory(customCategory: String) = intent {
-        copy(
-            customCategory = customCategory,
-        )
+    fun updateCustomCategory(customCategory: String) {
+        if (!USER_INPUT_REGEX.matches(customCategory)) { // 한글, 영문 0~10 글자
+            if (customCategory.length > 10) { // 길이 넘친 경우
+                postSideEffect(LedgerEditSideEffect.ShowNotValidSnackbarCategory)
+            }
+            return // 특수문자는 입력 안 됨
+        }
+
+        intent {
+            copy(
+                customCategory = customCategory,
+            )
+        }
     }
 
     fun showCustomCategoryButton() {

--- a/feature/received/src/main/java/com/susu/feature/received/navigation/ReceivedNavigation.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/navigation/ReceivedNavigation.kt
@@ -139,6 +139,7 @@ fun NavGraphBuilder.receivedNavGraph(
     ) {
         LedgerEditRoute(
             popBackStack = popBackStack,
+            onShowSnackbar = onShowSnackbar,
         )
     }
 

--- a/feature/received/src/main/java/com/susu/feature/received/navigation/ReceivedNavigation.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/navigation/ReceivedNavigation.kt
@@ -202,6 +202,7 @@ fun NavGraphBuilder.receivedNavGraph(
         ReceivedEnvelopeEditRoute(
             popBackStack = popBackStack,
             handleException = handleException,
+            onShowSnackbar = onShowSnackbar,
         )
     }
 }

--- a/feature/received/src/main/java/com/susu/feature/received/navigation/ReceivedNavigation.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/navigation/ReceivedNavigation.kt
@@ -159,6 +159,7 @@ fun NavGraphBuilder.receivedNavGraph(
             popBackStack = popBackStack,
             popBackStackWithLedger = popBackStackWithLedger,
             handleException = handleException,
+            onShowSnackbar = onShowSnackbar,
         )
     }
 

--- a/feature/received/src/main/res/values/strings.xml
+++ b/feature/received/src/main/res/values/strings.xml
@@ -72,4 +72,6 @@
 
     <string name="ledger_snackbar_category_validation">경조사는 10글자까지만 입력 가능해요</string>
     <string name="ledger_snackbar_category_name_validation">경조사명은 10글자까지만 입력 가능해요</string>
+
+    <string name="money_content_snackbar_validation">금액은 20억원까지만 입력 가능해요</string>
 </resources>

--- a/feature/received/src/main/res/values/strings.xml
+++ b/feature/received/src/main/res/values/strings.xml
@@ -71,4 +71,5 @@
     <string name="ledger_edit_screen_add_start_date">시작일만 지정</string>
 
     <string name="ledger_snackbar_category_validation">경조사는 10글자까지만 입력 가능해요</string>
+    <string name="ledger_snackbar_category_name_validation">경조사명은 10글자까지만 입력 가능해요</string>
 </resources>

--- a/feature/received/src/main/res/values/strings.xml
+++ b/feature/received/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
 
     <string name="money_content_snackbar_validation">금액은 20억원까지만 입력 가능해요</string>
     <string name="name_content_snackbar_validation">이름은 10글자까지만 입력 가능해요</string>
+    <string name="relationship_content_snackbar_validation">나와의 관계는 10글자까지만 입력 가능해요</string>
     <string name="present_content_snackbar_validation">선물은 30글자까지만 입력 가능해요</string>
     <string name="phone_content_snackbar_validation">연락처는 11자리까지만 입력 가능해요</string>
     <string name="memo_content_snackbar_validation">메모는 30글자까지만 입력 가능해요</string>

--- a/feature/received/src/main/res/values/strings.xml
+++ b/feature/received/src/main/res/values/strings.xml
@@ -40,7 +40,7 @@
     <string name="more_content_description">복수로 선택하셔도 좋아요</string>
     <string name="name_content_title">누구에게 받았나요</string>
     <string name="name_content_placeholder">이름을 입력해주세요</string>
-    <string name="phone_content_placeholder">01012345678</string>
+    <string name="phone_content_placeholder">010-1234-5678</string>
     <string name="phone_content_title">%s님의 연락처를 남겨주세요</string>
     <string name="phone_content_title_highlight">%s님의</string>
     <string name="present_content_title">받은 선물을 알려주세요</string>
@@ -54,7 +54,7 @@
     <string name="received_envelope_edit_screen_visited">방문 여부</string>
     <string name="received_envelope_edit_screen_present">선물</string>
     <string name="received_envelope_edit_screen_present_placeholder">한끼 식사</string>
-    <string name="received_envelope_edit_screen_phone_number_placeholder">01012345678</string>
+    <string name="received_envelope_edit_screen_phone_number_placeholder">010-1234-5678</string>
     <string name="received_envelope_edit_screen_memo_placeholder">입력해주세요</string>
     <string name="envelop_add_step_visited">방문여부</string>
     <string name="envelop_add_step_present">선물</string>
@@ -69,10 +69,8 @@
     <string name="toast_delete_envelope_success">봉투가 삭제됐어요</string>
     <string name="ledger_edit_screen_add_end_date">종료일 추가</string>
     <string name="ledger_edit_screen_add_start_date">시작일만 지정</string>
-
     <string name="ledger_snackbar_category_validation">경조사는 10글자까지만 입력 가능해요</string>
     <string name="ledger_snackbar_category_name_validation">경조사명은 10글자까지만 입력 가능해요</string>
-
     <string name="money_content_snackbar_validation">100억 미만의 금액만 입력 가능해요</string>
     <string name="name_content_snackbar_validation">이름은 10글자까지만 입력 가능해요</string>
     <string name="relationship_content_snackbar_validation">나와의 관계는 10글자까지만 입력 가능해요</string>

--- a/feature/received/src/main/res/values/strings.xml
+++ b/feature/received/src/main/res/values/strings.xml
@@ -77,4 +77,5 @@
     <string name="name_content_snackbar_validation">이름은 10글자까지만 입력 가능해요</string>
     <string name="present_content_snackbar_validation">선물은 30글자까지만 입력 가능해요</string>
     <string name="phone_content_snackbar_validation">연락처는 11자리까지만 입력 가능해요</string>
+    <string name="memo_content_snackbar_validation">메모는 30글자까지만 입력 가능해요</string>
 </resources>

--- a/feature/received/src/main/res/values/strings.xml
+++ b/feature/received/src/main/res/values/strings.xml
@@ -69,4 +69,6 @@
     <string name="toast_delete_envelope_success">봉투가 삭제됐어요</string>
     <string name="ledger_edit_screen_add_end_date">종료일 추가</string>
     <string name="ledger_edit_screen_add_start_date">시작일만 지정</string>
+
+    <string name="ledger_snackbar_category_validation">경조사는 10글자까지만 입력 가능해요</string>
 </resources>

--- a/feature/received/src/main/res/values/strings.xml
+++ b/feature/received/src/main/res/values/strings.xml
@@ -76,4 +76,5 @@
     <string name="money_content_snackbar_validation">금액은 20억원까지만 입력 가능해요</string>
     <string name="name_content_snackbar_validation">이름은 10글자까지만 입력 가능해요</string>
     <string name="present_content_snackbar_validation">선물은 30글자까지만 입력 가능해요</string>
+    <string name="phone_content_snackbar_validation">연락처는 11자리까지만 입력 가능해요</string>
 </resources>

--- a/feature/received/src/main/res/values/strings.xml
+++ b/feature/received/src/main/res/values/strings.xml
@@ -73,7 +73,7 @@
     <string name="ledger_snackbar_category_validation">경조사는 10글자까지만 입력 가능해요</string>
     <string name="ledger_snackbar_category_name_validation">경조사명은 10글자까지만 입력 가능해요</string>
 
-    <string name="money_content_snackbar_validation">금액은 20억원까지만 입력 가능해요</string>
+    <string name="money_content_snackbar_validation">100억 미만의 금액만 입력 가능해요</string>
     <string name="name_content_snackbar_validation">이름은 10글자까지만 입력 가능해요</string>
     <string name="relationship_content_snackbar_validation">나와의 관계는 10글자까지만 입력 가능해요</string>
     <string name="present_content_snackbar_validation">선물은 30글자까지만 입력 가능해요</string>

--- a/feature/received/src/main/res/values/strings.xml
+++ b/feature/received/src/main/res/values/strings.xml
@@ -74,4 +74,5 @@
     <string name="ledger_snackbar_category_name_validation">경조사명은 10글자까지만 입력 가능해요</string>
 
     <string name="money_content_snackbar_validation">금액은 20억원까지만 입력 가능해요</string>
+    <string name="name_content_snackbar_validation">이름은 10글자까지만 입력 가능해요</string>
 </resources>

--- a/feature/received/src/main/res/values/strings.xml
+++ b/feature/received/src/main/res/values/strings.xml
@@ -75,4 +75,5 @@
 
     <string name="money_content_snackbar_validation">금액은 20억원까지만 입력 가능해요</string>
     <string name="name_content_snackbar_validation">이름은 10글자까지만 입력 가능해요</string>
+    <string name="present_content_snackbar_validation">선물은 30글자까지만 입력 가능해요</string>
 </resources>

--- a/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/phone/PhoneContent.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeadd/content/phone/PhoneContent.kt
@@ -28,6 +28,7 @@ import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.core.ui.util.AnnotatedText
+import com.susu.core.ui.util.PhoneVisualTransformation
 import com.susu.feature.sent.R
 import kotlinx.coroutines.android.awaitFrame
 import kotlinx.coroutines.launch
@@ -109,6 +110,7 @@ fun PhoneContent(
             placeholderColor = Gray40,
             modifier = modifier.fillMaxWidth().focusRequester(focusRequester),
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            visualTransformation = PhoneVisualTransformation(),
         )
         Spacer(modifier = modifier.size(SusuTheme.spacing.spacing_xl))
     }

--- a/feature/sent/src/main/java/com/susu/feature/envelopedetail/SentEnvelopeDetailScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopedetail/SentEnvelopeDetailScreen.kt
@@ -31,6 +31,7 @@ import com.susu.core.ui.DialogToken
 import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.core.ui.extension.toMoneyFormat
+import com.susu.core.ui.extension.toPhoneNumber
 import com.susu.core.ui.util.to_yyyy_korYear_M_korMonth_d_korDay
 import com.susu.feature.envelopedetail.component.DetailItem
 import com.susu.feature.sent.R
@@ -187,7 +188,7 @@ fun SentEnvelopeDetailScreen(
                         )
                         DetailItem(
                             categoryText = stringResource(com.susu.core.ui.R.string.word_phone_number),
-                            contentText = friend.phoneNumber,
+                            contentText = if (friend.phoneNumber.isNullOrEmpty()) "" else friend.phoneNumber.toPhoneNumber(),
                             isEmptyContent = friend.phoneNumber.isEmpty(),
                         )
                         DetailItem(

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditScreen.kt
@@ -55,6 +55,7 @@ import com.susu.core.model.Relationship
 import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.core.ui.extension.susuClickable
+import com.susu.core.ui.util.PhoneVisualTransformation
 import com.susu.core.ui.util.to_yyyy_korYear_M_korMonth_d_korDay
 import com.susu.feature.envelopeedit.component.EditDetailItem
 import com.susu.feature.sent.R
@@ -385,6 +386,7 @@ fun SentEnvelopeEditScreen(
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                         modifier = Modifier.fillMaxWidth(),
                         maxLines = 2,
+                        visualTransformation = PhoneVisualTransformation(),
                     )
                 }
                 EditDetailItem(

--- a/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditViewModel.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopeedit/SentEnvelopeEditViewModel.kt
@@ -123,7 +123,7 @@ class SentEnvelopeEditViewModel @Inject constructor(
 
     fun updateMemo(memo: String?) {
         if (memo != null && memo.length > 30) {
-            postSideEffect(SentEnvelopeEditSideEffect.ShowPresentNotValidSnackbar)
+            postSideEffect(SentEnvelopeEditSideEffect.ShowMemoNotValidSnackbar)
             return
         }
         intent { copy(memo = memo?.ifEmpty { null }) }

--- a/feature/sent/src/main/res/values/strings.xml
+++ b/feature/sent/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="content_description_envelope_show_history">내역 보기</string>
     <string name="sent_envelope_edit_category_name_placeholder">김철수</string>
     <string name="sent_envelope_edit_category_present_placeholder">한끼 식사</string>
-    <string name="sent_envelope_edit_category_phone_placeholder">01012345678</string>
+    <string name="sent_envelope_edit_category_phone_placeholder">010-1234-5678</string>
     <string name="sent_envelope_edit_category_memo_placeholder">입력해주세요</string>
     <string name="sent_envelope_edit_save">저장</string>
 
@@ -25,7 +25,7 @@
     <string name="sent_envelope_add_present_placeholder">무엇을 선물했나요</string>
     <string name="sent_envelope_add_phone_title">%s님의 연락처를 남겨주세요</string>
     <string name="sent_envelope_add_phone_title_highlight">%s님의 </string>
-    <string name="sent_envelope_add_phone_placeholder">01012345678</string>
+    <string name="sent_envelope_add_phone_placeholder">010-1234-5678</string>
     <string name="sent_envelope_add_memo_title">추가로 남기실 내용이 있나요</string>
     <string name="sent_envelope_add_memo_placeholder">입력해주세요</string>
     <string name="sent_envelope_add_next">다음</string>

--- a/feature/sent/src/main/res/values/strings.xml
+++ b/feature/sent/src/main/res/values/strings.xml
@@ -62,7 +62,7 @@
     <string name="sent_envelope_money_diff_plus">+%1$s원</string>
     <string name="sent_envelope_money_diff_same">%1$s원</string>
 
-    <string name="sent_snackbar_money_validation">금액은 20억원까지만 입력 가능해요</string>
+    <string name="sent_snackbar_money_validation">100억 미만의 금액만 입력 가능해요</string>
     <string name="sent_snackbar_name_validation">이름은 10글자까지만 입력 가능해요</string>
     <string name="sent_snackbar_relationship_validation">나와의 관계는 10글자까지만 입력 가능해요</string>
     <string name="sent_snackbar_category_validation">경조사는 10글자까지만 입력 가능해요</string>


### PR DESCRIPTION
## 💡 Issue
- Resolved: #이슈번호

## 🌱 Key changes
받아요 유효성 검사 적용 작업 위주로 진행했습니다.

## ✅ To Reviewers
- 금액 부분 유효성 검사 서버 쪽에서 99억 해주신다고 하셨고, 이 부분에 따른 토스트 메시지 변경사항 있습니다.
   [ 바뀐 토스트 메시지 ] "100억 미만의 금액만 입력 가능해요"
- 보내요 부분 중에 토스트 메시지 하나가 잘못 매칭되어있어서 수정해놨습니다.
- 받아요 장부 봉투 리스트에서 디바이스 화면 작을 때 이름이 잘려서 나와서 보내요와 동일하게 ellipsis 적용했습니다.
- 노션 '정책 수정' 부분에 연락처 형식이 [000-0000-0000]으로 수정되어있어서 적용했습니다. (보내요, 받아요 모두 적용)
   (예전에 compose 스터디할 때 수진님께서 하셨던게 기억나서 재빠르게 긁어왔습니다ㅎ.. 샤라웃 수진님)

cf.) 제가 빼먹은 부분도 있을 것 같아서 확인 한번 해주시면 감사하겠습니다!

## 📸 스크린샷
|<img width="270" alt="image" src="https://github.com/YAPP-Github/oksusu-susu-android/assets/70886911/9d074c09-f62b-4ef5-b011-74e8cf244abc">|<img width="270" alt="image" src="https://github.com/YAPP-Github/oksusu-susu-android/assets/70886911/b773963e-079f-4c29-a985-edde236520cf">|<img width="300" alt="image" src="https://github.com/YAPP-Github/oksusu-susu-android/assets/70886911/35e91273-ec13-48a4-baf1-91f313e698b0">|
|:--:|:--:|:--:|
|연락처 형식 수정|ellipsis 적용|토스트 메시지 변경|
