### PR TITLE
Qa/80 출생년도 '미선택' 선택 시, 강제종료

### DIFF
--- a/core/model/src/main/java/com/susu/core/model/SignUpUser.kt
+++ b/core/model/src/main/java/com/susu/core/model/SignUpUser.kt
@@ -4,5 +4,5 @@ data class SignUpUser(
     val name: String,
     val gender: String?,
     val termAgreement: List<Int>,
-    val birth: Int,
+    val birth: Int?,
 )

--- a/data/src/main/java/com/susu/data/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/susu/data/data/repository/UserRepositoryImpl.kt
@@ -41,7 +41,7 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun patchUserInfo(name: String, gender: String?, birth: Int): User {
+    override suspend fun patchUserInfo(name: String, gender: String?, birth: Int?): User {
         val localUserInfo = dataStore.data.map { preferences ->
             preferences[userKey]
         }.firstOrNull() ?: throw UserNotFoundException()

--- a/data/src/main/java/com/susu/data/remote/model/request/UserRequest.kt
+++ b/data/src/main/java/com/susu/data/remote/model/request/UserRequest.kt
@@ -22,5 +22,5 @@ fun SignUpUser.toData() = UserSignUpRequest(
 data class UserPatchRequest(
     val name: String,
     val gender: String?,
-    val birth: Int,
+    val birth: Int?,
 )

--- a/domain/src/main/java/com/susu/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/com/susu/domain/repository/UserRepository.kt
@@ -4,7 +4,7 @@ import com.susu.core.model.User
 
 interface UserRepository {
     suspend fun getUserInfo(): User
-    suspend fun patchUserInfo(name: String, gender: String?, birth: Int): User
+    suspend fun patchUserInfo(name: String, gender: String?, birth: Int?): User
     suspend fun logout()
     suspend fun withdraw()
 }

--- a/domain/src/main/java/com/susu/domain/usecase/mypage/PatchUserUseCase.kt
+++ b/domain/src/main/java/com/susu/domain/usecase/mypage/PatchUserUseCase.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 class PatchUserUseCase @Inject constructor(
     private val userRepository: UserRepository,
 ) {
-    suspend operator fun invoke(name: String, gender: String?, birth: Int) = runCatchingIgnoreCancelled {
+    suspend operator fun invoke(name: String, gender: String?, birth: Int?) = runCatchingIgnoreCancelled {
         userRepository.patchUserInfo(name = name, gender = gender, birth = birth)
     }
 }

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/SignUpViewModel.kt
@@ -5,6 +5,7 @@ import com.susu.core.model.SignUpUser
 import com.susu.core.model.exception.UnknownException
 import com.susu.core.ui.Gender
 import com.susu.core.ui.SnsProviders
+import com.susu.core.ui.USER_BIRTH_RANGE
 import com.susu.core.ui.USER_INPUT_REGEX
 import com.susu.core.ui.USER_NAME_MAX_LENGTH
 import com.susu.core.ui.base.BaseViewModel
@@ -90,7 +91,11 @@ class SignUpViewModel @Inject constructor(
                         signUpUser = SignUpUser(
                             name = uiState.value.name,
                             gender = uiState.value.gender.content,
-                            birth = uiState.value.birth,
+                            birth = if (uiState.value.birth in USER_BIRTH_RANGE) {
+                                uiState.value.birth
+                            } else {
+                                null
+                            },
                             termAgreement = uiState.value.agreedTerms,
                         ),
                     ).onSuccess {

--- a/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/AdditionalContent.kt
+++ b/feature/loginsignup/src/main/java/com/susu/feature/loginsignup/signup/content/AdditionalContent.kt
@@ -20,7 +20,7 @@ import com.susu.core.designsystem.component.button.SusuGhostButton
 import com.susu.core.designsystem.theme.Gray60
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.ui.Gender
-import java.time.LocalDate
+import com.susu.core.ui.USER_BIRTH_RANGE
 
 @Composable
 fun AdditionalContent(
@@ -36,7 +36,11 @@ fun AdditionalContent(
     ) {
         Text(text = description, style = SusuTheme.typography.title_m)
         Spacer(modifier = Modifier.height(SusuTheme.spacing.spacing_xxl))
-        Text(text = "성별", style = SusuTheme.typography.title_xxxs, color = Gray60)
+        Text(
+            text = stringResource(id = com.susu.core.ui.R.string.word_gender),
+            style = SusuTheme.typography.title_xxxs,
+            color = Gray60,
+        )
         Spacer(modifier = Modifier.height(SusuTheme.spacing.spacing_xxs))
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -65,10 +69,14 @@ fun AdditionalContent(
         Text(text = stringResource(com.susu.core.ui.R.string.word_birth), style = SusuTheme.typography.title_xxxs, color = Gray60)
         SusuGhostButton(
             modifier = Modifier.fillMaxWidth(),
-            text = stringResource(
-                id = com.susu.core.designsystem.R.string.word_year_format,
-                if (selectedYear < 0) LocalDate.now().year else selectedYear,
-            ),
+            text = if (selectedYear in USER_BIRTH_RANGE) {
+                stringResource(
+                    id = com.susu.core.designsystem.R.string.word_year_format,
+                    selectedYear,
+                )
+            } else {
+                stringResource(id = com.susu.core.designsystem.R.string.word_not_select)
+            },
             color = GhostButtonColor.Black,
             style = MediumButtonStyle.height60,
             isClickable = true,


### PR DESCRIPTION

## 🌱 Key changes
- 기존에 출생년도 미선택 시 `0`을 사용했었는데, 서버 유효성 검사가 생기면서 `Bad Request`가 떨어졌습니다.
    - 미선택인 경우 'null'을 보내도록 수정했습니다.
- 원래 QA 사항과 별개로, 회원가입 시 출생년도 '미선택'이 아니라 '0년'으로 표기되고 있던 문제를 고쳤습니다.
