### PR TITLE
Qa/backlog 백로그 QA 일부 반영

### DIFF
--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/dialog/SusuCheckedDialog.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/dialog/SusuCheckedDialog.kt
@@ -105,7 +105,7 @@ fun SusuCheckedDialog(
                         text = it,
                         onClick = onDismissRequest,
                     )
-                    Spacer(modifier = Modifier.height(SusuTheme.spacing.spacing_xxs))
+                    Spacer(modifier = Modifier.width(SusuTheme.spacing.spacing_xxs))
                 }
                 SusuFilledButton(
                     modifier = Modifier.weight(1f),

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/dialog/SusuDialog.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/dialog/SusuDialog.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -74,7 +75,7 @@ fun SusuDialog(
                         text = it,
                         onClick = onDismissRequest,
                     )
-                    Spacer(modifier = Modifier.height(SusuTheme.spacing.spacing_xxs))
+                    Spacer(modifier = Modifier.width(SusuTheme.spacing.spacing_xxs))
                 }
                 SusuFilledButton(
                     modifier = Modifier.weight(1f),

--- a/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuTextField.kt
+++ b/core/designsystem/src/main/java/com/susu/core/designsystem/component/textfield/SusuTextField.kt
@@ -86,7 +86,7 @@ fun SusuPriceTextField(
     val moneyUnitString = stringResource(R.string.money_unit)
     SusuBasicTextField(
         modifier = modifier,
-        text = text,
+        text = text.toLongOrNull()?.toString() ?: "",
         onTextChange = onTextChange,
         placeholder = placeholder,
         textColor = textColor,

--- a/data/src/main/java/com/susu/data/data/repository/ExcelRepositoryImpl.kt
+++ b/data/src/main/java/com/susu/data/data/repository/ExcelRepositoryImpl.kt
@@ -19,7 +19,7 @@ class ExcelRepositoryImpl @Inject constructor(
         val request = DownloadManager.Request(url.toUri())
             .setMimeType(mimeType)
             .setAllowedOverMetered(true)
-            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE)
+            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
             .setTitle(downloaderName)
             .addRequestHeader(headerTokenName, token)
             .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName)

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/main/MyPageDefaultScreen.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/main/MyPageDefaultScreen.kt
@@ -198,7 +198,10 @@ fun MyPageDefaultScreen(
             titleTextStyle = SusuTheme.typography.title_m,
             action = {
                 Row(
-                    modifier = Modifier.susuClickable(onClick = navigateToInfo),
+                    modifier = Modifier.susuClickable(
+                        rippleEnabled = false,
+                        onClick = navigateToInfo
+                    ),
                 ) {
                     Text(
                         text = stringResource(com.susu.feature.mypage.R.string.mypage_default_my_info),

--- a/feature/mypage/src/main/java/com/susu/feature/mypage/main/MyPageDefaultScreen.kt
+++ b/feature/mypage/src/main/java/com/susu/feature/mypage/main/MyPageDefaultScreen.kt
@@ -200,7 +200,7 @@ fun MyPageDefaultScreen(
                 Row(
                     modifier = Modifier.susuClickable(
                         rippleEnabled = false,
-                        onClick = navigateToInfo
+                        onClick = navigateToInfo,
                     ),
                 ) {
                     Text(

--- a/feature/received/src/main/java/com/susu/feature/received/ledgerdetail/component/LedgerDetailEnvelopeContainer.kt
+++ b/feature/received/src/main/java/com/susu/feature/received/ledgerdetail/component/LedgerDetailEnvelopeContainer.kt
@@ -148,8 +148,8 @@ fun LedgerDetailEnvelopeContainerPreview() {
                     relation = "관계관계관계",
                     customRelation = null,
                     description = null,
-                )
-            )
+                ),
+            ),
         ) {
         }
     }

--- a/feature/sent/src/main/java/com/susu/feature/envelopefilter/EnvelopeFilterScreen.kt
+++ b/feature/sent/src/main/java/com/susu/feature/envelopefilter/EnvelopeFilterScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -152,7 +151,7 @@ fun EnvelopeFilterScreen(
     Column(
         modifier = Modifier
             .background(SusuTheme.colorScheme.background10)
-            .fillMaxSize()
+            .fillMaxSize(),
     ) {
         SusuDefaultAppBar(
             leftIcon = {

--- a/feature/statistics/src/main/java/com/susu/feature/statistics/component/StatisticsTab.kt
+++ b/feature/statistics/src/main/java/com/susu/feature/statistics/component/StatisticsTab.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.susu.core.designsystem.theme.Gray10
@@ -57,14 +58,15 @@ fun StatisticsTabItem(
     onClick: () -> Unit,
 ) {
     Box(
-        modifier = modifier.fillMaxSize().background(
-            color = if (isSelected) {
-                Gray20
-            } else {
-                Gray10
-            },
-            shape = RoundedCornerShape(4.dp),
-        ).susuClickable(onClick = onClick),
+        modifier = modifier.fillMaxSize()
+            .clip(RoundedCornerShape(4.dp))
+            .background(
+                color = if (isSelected) {
+                    Gray20
+                } else {
+                    Gray10
+                },
+            ).susuClickable(onClick = onClick),
     ) {
         Text(
             modifier = Modifier.align(Alignment.Center),

--- a/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsOptionSlot.kt
+++ b/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsOptionSlot.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -115,7 +116,9 @@ fun OptionSlot(
     onClick: () -> Unit = {},
 ) {
     Row(
-        modifier = modifier.background(color = Gray10, shape = RoundedCornerShape(4.dp))
+        modifier = modifier
+            .clip(RoundedCornerShape(4.dp))
+            .background(color = Gray10)
             .susuClickable(onClick = onClick)
             .padding(
                 horizontal = SusuTheme.spacing.spacing_xxs,


### PR DESCRIPTION

## 🌱 Key changes
<img width="780" alt="스크린샷 2024-04-01 오후 3 50 23" src="https://github.com/YAPP-Github/oksusu-susu-android/assets/69582122/85c98b9d-f662-4617-8c31-e7eddc3ee8c1">

- 성과 공유회 이후 정리한 백로그의 qa 항목을 반영했습니다 (OKSUSU - 문서 - 백로그)
- 금액 입력칸 크래시
    - `000원`, `0123`원 등 `PriceVisualTransformation`의 규칙을 벗어나는 경우 자릿수가 밀려 크래시가 발생
    - VisualTransform이 되기 전에 입력 내용을 Long으로 변환했다가 다시 String으로 변환하도록 수정했습니다.
- 엑셀 다운로드
    - 근본적인 문제는 아직 해결 못했습니다만.. 상단바 알림 옵션을 조정했습니다
    - 기존) 다운로드 중에만 표시
    - 개선) 다운로드 중 + 다운로드 완료 알림 표시. 완료 알림을 눌러서 파일로 이동 가능합니다.
- 터치 영역을 벗어난 ripple
    - 전부 제가 한 부분이더라고요 (죄송합니다)
    - 통계 탭, 수수 통계 옵션 버튼 ripple 영역 조정   
    - 마이페이지 - 내 정보 ripple 영역이 어색해서 아예 제거했습니다
    - Dialog 컴포넌트 버튼 사이 간격 추가

## ✅ To Reviewers
- DownloadManager에서 잡지 못하는 엑셀 다운로드 실패 발생조건은 알아봐야 할 것 같습니다 🥲

여담. 이제 본격적으로 개선작업 들어가기 전에 안스 재설치해서 gradle 고치려고요........ 
